### PR TITLE
docs: replace all occurrences of Discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Welcome to [TheAlgorithms/TypeScript](https://github.com/TheAlgorithms/TypeScript)! Before sending your pull requests,
 make sure that you **read the whole guidelines**. If you have any doubt on the contributing guide, please feel free to
-[state it clearly in an issue](https://github.com/TheAlgorithms/TypeScript/issues/new) or on our [**Discord server**](https://discord.gg/c7MnfGFGa6).
+[state it clearly in an issue](https://github.com/TheAlgorithms/TypeScript/issues/new) or on our [**Discord server**](https://the-algorithms.com/discord/).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ if you make any mistakes. The names of the maintainers of this repository are li
 [welcome]: https://img.shields.io/static/v1.svg?label=Contributions&message=Welcome&color=0059b3
 
 <!-- External Links -->
-[discord-server]: https://discord.gg/c7MnfGFGa6
+[discord-server]: https://the-algorithms.com/discord/
 [actions]: https://github.com/TheAlgorithms/TypeScript/actions
 [repositories]: https://github.com/orgs/TheAlgorithms/repositories
 [help-wanted]: https://github.com/TheAlgorithms/TypeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22


### PR DESCRIPTION
Use the new Discord invitation link specified in the related issue.

Closes #47