### PR TITLE
fix: tail pointer of doubly linked list does not reference to undefined

### DIFF
--- a/data_structures/doubly_linked_list.ts
+++ b/data_structures/doubly_linked_list.ts
@@ -103,7 +103,7 @@ export class DoublyLinkedList<T> {
         if (!this.head) {
             this.head = newNode;
         } else {
-            this.tail!.next = newNode;
+            this.tail!.next = undefined;
             newNode.prev = this.tail;
         }
 


### PR DESCRIPTION
Currently, the `tail.next` reference references to the newly appended node in the `append()` function instead of `undefined`.