### PR TITLE
feat: add dijkstra with adjacency list and heap increasePriority

### DIFF
--- a/data_structures/heap/test/max_heap.test.ts
+++ b/data_structures/heap/test/max_heap.test.ts
@@ -7,7 +7,10 @@ describe("MaxHeap", () => {
   ];
 
   beforeEach(() => {
-    heap = new MaxHeap(elements);
+    heap = new MaxHeap();
+    for (let element of elements) {
+      heap.insert(element);
+    }
   });
 
   it("should initialize a heap from input array", () => {

--- a/data_structures/heap/test/min_heap.test.ts
+++ b/data_structures/heap/test/min_heap.test.ts
@@ -1,4 +1,4 @@
-import { MinHeap } from "../heap";
+import { MinHeap, PriorityQueue } from "../heap";
 
 describe("MinHeap", () => {
   let heap: MinHeap<number>;
@@ -7,7 +7,10 @@ describe("MinHeap", () => {
   ];
 
   beforeEach(() => {
-    heap = new MinHeap(elements);
+    heap = new MinHeap();
+    for (let element of elements) {
+      heap.insert(element);
+    }
   });
 
   it("should initialize a heap from input array", () => {
@@ -27,7 +30,7 @@ describe("MinHeap", () => {
     heap.check();
   });
 
-  const extract_all = (heap: MinHeap<number>) => {
+  const extract_all = (heap: MinHeap<number>, elements: number[]) => {
     [...elements].sort((a, b) => a - b).forEach((element: number) => {
       expect(heap.extract()).toEqual(element);
     });
@@ -36,7 +39,7 @@ describe("MinHeap", () => {
   }
 
   it("should remove and return the min elements in order", () => {
-    extract_all(heap);
+    extract_all(heap, elements);
   });
 
   it("should insert all, then remove and return the min elements in order", () => {
@@ -46,6 +49,27 @@ describe("MinHeap", () => {
     });
     heap.check();
     expect(heap.size()).toEqual(elements.length);
-    extract_all(heap);
+    extract_all(heap, elements);
+  });
+
+  it("should increase priority", () => {
+    let heap = new PriorityQueue((a: number) => { return a; }, elements.length);
+    elements.forEach((element: number) => {
+      heap.insert(element);
+    });
+    heap.check();
+    expect(heap.size()).toEqual(elements.length);
+
+    heap.increasePriority(55, 14);
+    heap.increasePriority(18, 16);
+    heap.increasePriority(81, 72);
+    heap.increasePriority(9, 0);
+    heap.increasePriority(43, 33);
+    heap.check();
+    // Elements after increasing priority
+    const newElements: number[] = [
+      12, 4, 33, 42, 0, 7, 39, 16, 14, 1, 51, 34, 72, 16,
+    ];
+    extract_all(heap, newElements);
   });
 });

--- a/graph/dijkstra.ts
+++ b/graph/dijkstra.ts
@@ -1,4 +1,4 @@
-import { MinHeap } from '../data_structures/heap/min_heap';
+import { MinHeap, PriorityQueue } from '../data_structures/heap/heap';
 /**
  * @function dijkstra
  * @description Compute the shortest path from a source node to all other nodes. The input graph is in adjacency list form. It is a multidimensional array of edges. graph[i] holds the edges for the i'th node. Each edge is a 2-tuple where the 0'th item is the destination node, and the 1'th item is the edge weight.
@@ -11,22 +11,24 @@ import { MinHeap } from '../data_structures/heap/min_heap';
  * @see https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
  */
 export const dijkstra = (graph: [number, number][][], start: number): number[] => {
-  // We use a priority queue to make sure we always visit the closest node. By using a MinHeap,
-  // finding the next node is O(log(V))
-  let priorityQueue = new MinHeap([start]);
+  // We use a priority queue to make sure we always visit the closest node. The
+  // queue makes comparisons based on path weights.
+  let priorityQueue = new PriorityQueue((a: [number, number]) => { return a[0] }, graph.length, (a: [number, number], b: [number, number]) => { return a[1] < b[1] });
+  priorityQueue.insert([start, 0]);
   // We save the shortest distance to each node in `distances`. If a node is
   // unreachable from the start node, its distance is Infinity.
   let distances = Array(graph.length).fill(Infinity);
   distances[start] = 0;
 
   while (priorityQueue.size() > 0) {
-    const node = priorityQueue.extract();
+    const [node, _] = priorityQueue.extract();
     graph[node].forEach(([child, weight]) => {
       let new_distance = distances[node] + weight;
       if (new_distance < distances[child]) {
         // Found a new shortest path to child node. Record its distance and add child to the queue.
+        // If the child already exists in the queue, the priority will be updated. This will make sure the queue will be at most size V (number of vertices).
+        priorityQueue.increasePriority(child, [child, weight]);
         distances[child] = new_distance;
-        priorityQueue.insert(child);
       }
     });
   }

--- a/graph/dijkstra.ts
+++ b/graph/dijkstra.ts
@@ -11,8 +11,8 @@
  */
 export const dijkstra = (graph: number[][], start: number): number[] => {
   let visited = Array(graph.length).fill(false);
-  let paths = Array(graph.length).fill(Number.MAX_SAFE_INTEGER);
-  paths[start] = 0;
+  let distances = Array(graph.length).fill(Infinity);
+  distances[start] = 0;
 
   let node = start;
   while (node !== -1) {
@@ -21,15 +21,15 @@ export const dijkstra = (graph: number[][], start: number): number[] => {
       if (child == node || weight === 0) {
         return;
       }
-      let new_path = paths[node] + weight;
-      if (new_path < paths[child]) {
-        paths[child] = new_path;
+      let new_path = distances[node] + weight;
+      if (new_path < distances[child]) {
+        distances[child] = new_path;
       }
     });
-    node = extract_min(paths, visited);
+    node = extract_min(distances, visited);
   }
 
-  return paths;
+  return distances;
 }
 
 const extract_min = (paths: number[], visited: boolean[]): number => {

--- a/graph/dijkstra.ts
+++ b/graph/dijkstra.ts
@@ -1,0 +1,50 @@
+/**
+ * @function dijkstra
+ * @description Compute the shortest path from a source node to all other nodes. The input graph is an adjacency matrix where `0` represents no edge, and a positive value represents the weight of the edge. All weights are positive.
+ * @Complexity_Analysis
+ * Time complexity: O(V^2)
+ * Space Complexity: O(V)
+ * @param {number[][]} graph - The adjacency matrix graph
+ * @param {number} start - The source node
+ * @return {number[]} - The shortest path to each node
+ * @see https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
+ */
+export const dijkstra = (graph: number[][], start: number): number[] => {
+  let visited = Array(graph.length).fill(false);
+  let paths = Array(graph.length).fill(Number.MAX_SAFE_INTEGER);
+  paths[start] = 0;
+
+  let node = start;
+  while (node !== -1) {
+    visited[node] = true;
+    graph[node].forEach((weight, child) => {
+      if (child == node || weight === 0) {
+        return;
+      }
+      let new_path = paths[node] + weight;
+      if (new_path < paths[child]) {
+        paths[child] = new_path;
+      }
+    });
+    node = extract_min(paths, visited);
+  }
+
+  return paths;
+}
+
+const extract_min = (paths: number[], visited: boolean[]): number => {
+  let min = Number.MAX_SAFE_INTEGER;
+  let node = -1;
+
+  for (let i = 0; i < paths.length; ++i) {
+    if (visited[i]) {
+      continue;
+    }
+    if (paths[i] < min) {
+      min = paths[i];
+      node = i;
+    }
+  }
+  return node;
+}
+

--- a/graph/dijkstra.ts
+++ b/graph/dijkstra.ts
@@ -1,50 +1,35 @@
+import { MinHeap } from '../data_structures/heap/min_heap';
 /**
  * @function dijkstra
- * @description Compute the shortest path from a source node to all other nodes. The input graph is an adjacency matrix where `0` represents no edge, and a positive value represents the weight of the edge. All weights are positive.
+ * @description Compute the shortest path from a source node to all other nodes. The input graph is in adjacency list form. It is a multidimensional array of edges. graph[i] holds the edges for the i'th node. Each edge is a 2-tuple where the 0'th item is the destination node, and the 1'th item is the edge weight.
  * @Complexity_Analysis
- * Time complexity: O(V^2)
+ * Time complexity: O((V+E)*log(V)). For fully connected graphs, it is O(E*log(V)).
  * Space Complexity: O(V)
- * @param {number[][]} graph - The adjacency matrix graph
+ * @param {[number, number][][]} graph - The graph in adjacency list form
  * @param {number} start - The source node
  * @return {number[]} - The shortest path to each node
  * @see https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
  */
-export const dijkstra = (graph: number[][], start: number): number[] => {
-  let visited = Array(graph.length).fill(false);
+export const dijkstra = (graph: [number, number][][], start: number): number[] => {
+  // We use a priority queue to make sure we always visit the closest node. By using a MinHeap,
+  // finding the next node is O(log(V))
+  let priorityQueue = new MinHeap([start]);
+  // We save the shortest distance to each node in `distances`. If a node is
+  // unreachable from the start node, its distance is Infinity.
   let distances = Array(graph.length).fill(Infinity);
   distances[start] = 0;
 
-  let node = start;
-  while (node !== -1) {
-    visited[node] = true;
-    graph[node].forEach((weight, child) => {
-      if (child == node || weight === 0) {
-        return;
-      }
-      let new_path = distances[node] + weight;
-      if (new_path < distances[child]) {
-        distances[child] = new_path;
+  while (priorityQueue.size() > 0) {
+    const node = priorityQueue.extract();
+    graph[node].forEach(([child, weight]) => {
+      let new_distance = distances[node] + weight;
+      if (new_distance < distances[child]) {
+        // Found a new shortest path to child node. Record its distance and add child to the queue.
+        distances[child] = new_distance;
+        priorityQueue.insert(child);
       }
     });
-    node = extract_min(distances, visited);
   }
 
   return distances;
 }
-
-const extract_min = (paths: number[], visited: boolean[]): number => {
-  let min = Number.MAX_SAFE_INTEGER;
-  let node = -1;
-
-  for (let i = 0; i < paths.length; ++i) {
-    if (visited[i]) {
-      continue;
-    }
-    if (paths[i] < min) {
-      min = paths[i];
-      node = i;
-    }
-  }
-  return node;
-}
-

--- a/graph/test/dijkstra.test.ts
+++ b/graph/test/dijkstra.test.ts
@@ -2,17 +2,17 @@ import { dijkstra } from "../dijkstra";
 
 describe("dijkstra", () => {
 
-  const init_graph = (N: number): number[][] => {
+  const init_graph = (N: number): [number, number][][] => {
     let graph = Array(N);
     for (let i = 0; i < N; ++i) {
-      graph[i] = Array(N).fill(0);
+      graph[i] = [];
     }
     return graph;
   }
 
-  const add_edge = (graph: number[][], a: number, b: number, weight: number) => {
-    graph[a][b] = weight;
-    graph[b][a] = weight;
+  const add_edge = (graph: [number, number][][], a: number, b: number, weight: number) => {
+    graph[a].push([b, weight]);
+    graph[b].push([a, weight]);
   }
 
   it("should return the correct value", () => {
@@ -31,13 +31,11 @@ describe("dijkstra", () => {
     add_edge(graph, 6, 7, 1);
     add_edge(graph, 6, 8, 6);
     add_edge(graph, 7, 8, 7);
-
     expect(dijkstra(graph, 0)).toStrictEqual([0, 4, 12, 19, 21, 11, 9, 8, 14]);
   });
 
   it("should return the correct value for single element graph", () => {
-    expect(dijkstra([[0]], 0)).toStrictEqual([0]);
-    expect(dijkstra([[10]], 0)).toStrictEqual([0]);
+    expect(dijkstra([[]], 0)).toStrictEqual([0]);
   });
 
   let linear_graph = init_graph(4);

--- a/graph/test/dijkstra.test.ts
+++ b/graph/test/dijkstra.test.ts
@@ -16,7 +16,6 @@ describe("dijkstra", () => {
   }
 
   it("should return the correct value", () => {
-    // Example from https://www.geeksforgeeks.org/dijkstras-shortest-path-algorithm-greedy-algo-7/
     let graph = init_graph(9);
     add_edge(graph, 0, 1, 4);
     add_edge(graph, 0, 7, 8);
@@ -54,8 +53,7 @@ describe("dijkstra", () => {
 
   let unreachable_graph = init_graph(3);
   add_edge(unreachable_graph, 0, 1, 1);
-  const m = Number.MAX_SAFE_INTEGER
-  test.each([[0, [0, 1, m]], [1, [1, 0, m]], [2, [m, m, 0]]])(
+  test.each([[0, [0, 1, Infinity]], [1, [1, 0, Infinity]], [2, [Infinity, Infinity, 0]]])(
     "correct result for graph with unreachable nodes with source node %i",
     (source, result) => {
       expect(dijkstra(unreachable_graph, source)).toStrictEqual(result);

--- a/graph/test/dijkstra.test.ts
+++ b/graph/test/dijkstra.test.ts
@@ -1,0 +1,65 @@
+import { dijkstra } from "../dijkstra";
+
+describe("dijkstra", () => {
+
+  const init_graph = (N: number): number[][] => {
+    let graph = Array(N);
+    for (let i = 0; i < N; ++i) {
+      graph[i] = Array(N).fill(0);
+    }
+    return graph;
+  }
+
+  const add_edge = (graph: number[][], a: number, b: number, weight: number) => {
+    graph[a][b] = weight;
+    graph[b][a] = weight;
+  }
+
+  it("should return the correct value", () => {
+    // Example from https://www.geeksforgeeks.org/dijkstras-shortest-path-algorithm-greedy-algo-7/
+    let graph = init_graph(9);
+    add_edge(graph, 0, 1, 4);
+    add_edge(graph, 0, 7, 8);
+    add_edge(graph, 1, 2, 8);
+    add_edge(graph, 1, 7, 11);
+    add_edge(graph, 2, 3, 7);
+    add_edge(graph, 2, 5, 4);
+    add_edge(graph, 2, 8, 2);
+    add_edge(graph, 3, 4, 9);
+    add_edge(graph, 3, 5, 14);
+    add_edge(graph, 4, 5, 10);
+    add_edge(graph, 5, 6, 2);
+    add_edge(graph, 6, 7, 1);
+    add_edge(graph, 6, 8, 6);
+    add_edge(graph, 7, 8, 7);
+
+    expect(dijkstra(graph, 0)).toStrictEqual([0, 4, 12, 19, 21, 11, 9, 8, 14]);
+  });
+
+  it("should return the correct value for single element graph", () => {
+    expect(dijkstra([[0]], 0)).toStrictEqual([0]);
+    expect(dijkstra([[10]], 0)).toStrictEqual([0]);
+  });
+
+  let linear_graph = init_graph(4);
+  add_edge(linear_graph, 0, 1, 1);
+  add_edge(linear_graph, 1, 2, 2);
+  add_edge(linear_graph, 2, 3, 3);
+  test.each([[0, [0, 1, 3, 6]], [1, [1, 0, 2, 5]], [2, [3, 2, 0, 3]], [3, [6, 5, 3, 0]]])(
+    "correct result for linear graph with source node %i",
+    (source, result) => {
+      expect(dijkstra(linear_graph, source)).toStrictEqual(result);
+    }
+  );
+
+  let unreachable_graph = init_graph(3);
+  add_edge(unreachable_graph, 0, 1, 1);
+  const m = Number.MAX_SAFE_INTEGER
+  test.each([[0, [0, 1, m]], [1, [1, 0, m]], [2, [m, m, 0]]])(
+    "correct result for graph with unreachable nodes with source node %i",
+    (source, result) => {
+      expect(dijkstra(unreachable_graph, source)).toStrictEqual(result);
+    }
+  );
+})
+


### PR DESCRIPTION
Add dijkstra shortest path algorithm for adjacency matrix.

We can get lower bounds on a graph with adjacency list representation using min/Fibonacci heap, but I think this solution is the lowest bound we can get for an adjacency matrix representation.