### PR TITLE
fix, test: Fix MinHeap sinkDown implementation, increase test coverage

### DIFF
--- a/data_structures/heap/max_heap.ts
+++ b/data_structures/heap/max_heap.ts
@@ -32,7 +32,7 @@ export class MaxHeap<T> extends Heap<T> {
     leftChildIndex: number,
     rightChildIndex: number
   ): number {
-    return (this.heap[leftChildIndex] || -Infinity) >
+    return this.heap[leftChildIndex] >
       (this.heap[rightChildIndex] || -Infinity)
       ? leftChildIndex
       : rightChildIndex;

--- a/data_structures/heap/min_heap.ts
+++ b/data_structures/heap/min_heap.ts
@@ -32,8 +32,8 @@ export class MinHeap<T> extends Heap<T> {
     leftChildIndex: number,
     rightChildIndex: number
   ): number {
-    return (this.heap[leftChildIndex] || -Infinity) <
-      (this.heap[rightChildIndex] || -Infinity)
+    return this.heap[leftChildIndex] <
+      (this.heap[rightChildIndex] || Infinity)
       ? leftChildIndex
       : rightChildIndex;
   }

--- a/data_structures/heap/test/max_heap.test.ts
+++ b/data_structures/heap/test/max_heap.test.ts
@@ -2,11 +2,11 @@ import { MaxHeap } from "../max_heap";
 
 describe("MaxHeap", () => {
   let heap: MaxHeap<number>;
+  const elements: number[] = [
+    12, 4, 43, 42, 9, 7, 39, 16, 55, 1, 51, 34, 81, 18,
+  ];
 
-  beforeAll(() => {
-    const elements: number[] = [
-      12, 4, 43, 42, 9, 7, 39, 16, 55, 1, 51, 34, 81, 18,
-    ];
+  beforeEach(() => {
     heap = new MaxHeap(elements);
   });
 
@@ -25,5 +25,27 @@ describe("MaxHeap", () => {
   it("should insert a new element and bubble Up the element to it correct index in the heap", () => {
     heap.insert(61);
     heap.check();
+  });
+
+  const extract_all = (heap: MaxHeap<number>) => {
+    [...elements].sort((a, b) => b - a).forEach((element: number) => {
+      expect(heap.extract()).toEqual(element);
+    });
+    heap.check();
+    expect(heap.size()).toEqual(0);
+  }
+
+  it("should remove and return the max elements in order", () => {
+    extract_all(heap);
+  });
+
+  it("should insert all, then remove and return the max elements in order", () => {
+    heap = new MaxHeap();
+    elements.forEach((element: number) => {
+      heap.insert(element);
+    });
+    heap.check();
+    expect(heap.size()).toEqual(elements.length);
+    extract_all(heap);
   });
 });

--- a/data_structures/heap/test/min_heap.test.ts
+++ b/data_structures/heap/test/min_heap.test.ts
@@ -2,11 +2,11 @@ import { MinHeap } from "../min_heap";
 
 describe("MinHeap", () => {
   let heap: MinHeap<number>;
+  const elements: number[] = [
+    12, 4, 43, 42, 9, 7, 39, 16, 55, 1, 51, 34, 81, 18,
+  ];
 
-  beforeAll(() => {
-    const elements: number[] = [
-      12, 4, 43, 42, 9, 7, 39, 16, 55, 1, 51, 34, 81, 18,
-    ];
+  beforeEach(() => {
     heap = new MinHeap(elements);
   });
 
@@ -25,5 +25,27 @@ describe("MinHeap", () => {
   it("should insert a new element and bubble Up the element to it correct index in the heap", () => {
     heap.insert(24);
     heap.check();
+  });
+
+  const extract_all = (heap: MinHeap<number>) => {
+    [...elements].sort((a, b) => a - b).forEach((element: number) => {
+      expect(heap.extract()).toEqual(element);
+    });
+    heap.check();
+    expect(heap.size()).toEqual(0);
+  }
+
+  it("should remove and return the min elements in order", () => {
+    extract_all(heap);
+  });
+
+  it("should insert all, then remove and return the min elements in order", () => {
+    heap = new MinHeap();
+    elements.forEach((element: number) => {
+      heap.insert(element);
+    });
+    heap.check();
+    expect(heap.size()).toEqual(elements.length);
+    extract_all(heap);
   });
 });


### PR DESCRIPTION
MinHeap  would break if we extract from a heap of two elements that looks like

```
    A
  /    \
B    undef
```

It would bubble up the right child and get

```
  undef
  /
B
```

I added more tests for MinHeap that inserts/extracts everything, and would have failed before this patch. I also added equivalent tests for MaxHeap.