### PR TITLE
chore: fix naming convention for maths functions

### DIFF
--- a/maths/absolute_value.ts
+++ b/maths/absolute_value.ts
@@ -1,15 +1,15 @@
 /**
- * @function AbsoluteValue
+ * @function absoluteValue
  * @description Calculate the absolute value of an input number.
  * @param {number} number - a numeric input value
  * @return {number} - Absolute number of input number
  * @see https://en.wikipedia.org/wiki/Absolute_value
- * @example AbsoluteValue(-10) = 10
- * @example AbsoluteValue(50) = 50
- * @example AbsoluteValue(0) = 0
+ * @example absoluteValue(-10) = 10
+ * @example absoluteValue(50) = 50
+ * @example absoluteValue(0) = 0
  */
 
-export const AbsoluteValue = (number: number): number => {
+export const absoluteValue = (number: number): number => {
   // if input number is less than 0, convert it to positive via double negation
   // e.g. if n = -2, then return -(-2) = 2
   return number < 0 ? -number : number;

--- a/maths/aliquot_sum.ts
+++ b/maths/aliquot_sum.ts
@@ -1,5 +1,5 @@
 /**
- * @function AliquotSum
+ * @function aliquotSum
  * @description Returns the aliquot sum of the provided number
  * @summary The aliquot sum of a number n is the sum of all the proper divisors
  * of n apart from n itself.
@@ -9,10 +9,10 @@
  * @param {number} num The input number
  * @return {number} The aliquot sum of the number
  * @see [Wikipedia](https://en.wikipedia.org/wiki/Aliquot_sum)
- * @example AliquotSum(18) = 21
- * @example AliquotSum(15) = 9
+ * @example aliquotSum(18) = 21
+ * @example aliquotSum(15) = 9
  */
-export const AliquotSum = (num: number): number => {
+export const aliquotSum = (num: number): number => {
   if (typeof num !== 'number') throw new TypeError('Input needs to be a number')
   if (num < 0) throw new TypeError('Input cannot be negative')
   if (!Number.isInteger(num)) throw new TypeError('Input cannot be a decimal')

--- a/maths/armstrong_number.ts
+++ b/maths/armstrong_number.ts
@@ -1,5 +1,5 @@
 /** 
- * @function ArmstrongNumber
+ * @function armstrongNumber
  * @description Check if the provided number is an Armstrong number or not.
  * @summary Armstrong numbers are numbers, the sum of whose digits each raised
  * to the power of the number of digits is equal to the number itself.
@@ -10,10 +10,10 @@
  * @return {boolean} Whether the input number is an Armstrong number
  * @see [Wikipedia](https://en.wikipedia.org/wiki/Armstrong_number)
  * @see [OEIS](https://oeis.org/A005188)
- * @example ArmstrongNumber(370) = true
- * @example ArmstrongNumber(10) = false
+ * @example armstrongNumber(370) = true
+ * @example armstrongNumber(10) = false
  */
-export const ArmstrongNumber = (num: number): boolean => {
+export const armstrongNumber = (num: number): boolean => {
   if (typeof num !== 'number' || num <= 0) return false;
 
   let compNum = 0

--- a/maths/binary_convert.ts
+++ b/maths/binary_convert.ts
@@ -1,14 +1,14 @@
 /**
- * @function BinaryConvert
+ * @function binaryConvert
  * @description Convert the decimal to binary.
  * @param {number} num - The input integer
  * @return {string} - Binary of num.
  * @see [BinaryConvert](https://www.programiz.com/javascript/examples/decimal-binary)
- * @example BinaryConvert(12) = 1100
- * @example BinaryConvert(12 + 2) = 1110
+ * @example binaryConvert(12) = 1100
+ * @example binaryConvert(12 + 2) = 1110
  */
 
-export const BinaryConvert = (num: number): string => {
+export const binaryConvert = (num: number): string => {
   let binary = ''
 
   while (num !== 0) {

--- a/maths/binomial_coefficient.ts
+++ b/maths/binomial_coefficient.ts
@@ -1,24 +1,24 @@
-import { Factorial } from "./factorial";
+import { factorial } from "./factorial";
 /**
- * @function BinomialCoefficient
+ * @function binomialCoefficient
  * @description Calculate the binomial coefficient (n choose k) of two input numbers.
  * @param {number} n - the total number of items
  * @param {number} k - the number of items to be chosen
  * @return {number} - Binomial coefficient (n choose k)
  * @see https://en.wikipedia.org/wiki/Binomial_coefficient
- * @example BinomialCoefficient(5, 2) = 10
- * @example BinomialCoefficient(10, 3) = 120
- * @example BinomialCoefficient(6, 0) = 1
+ * @example binomialCoefficient(5, 2) = 10
+ * @example binomialCoefficient(10, 3) = 120
+ * @example binomialCoefficient(6, 0) = 1
  */
 
-export const BinomialCoefficient = (n: number, k: number): number => {
+export const binomialCoefficient = (n: number, k: number): number => {
     // Check if k is larger than n or negative
     if (k > n || k < 0) {
         return 0;
     }
 
     // Calculate the binomial coefficient using the implemented factorial
-    const numerator = Factorial(n);
-    const denominator = Factorial(k) * Factorial(n - k);
+    const numerator = factorial(n);
+    const denominator = factorial(k) * factorial(n - k);
     return numerator / denominator;
 };

--- a/maths/digit_sum.ts
+++ b/maths/digit_sum.ts
@@ -1,14 +1,14 @@
 /**
- * @function DigitSum
+ * @function digitSum
  * @description Calculate the sum of all digits of a natural number (number base 10).
  * @param {number} num - A natural number.
  * @return {number} - Sum of all digits of given natural number.
  * @see https://en.wikipedia.org/wiki/Digit_sum
- * @example DigitSum(12) = 3
- * @example DigitSum(9045) = 18
+ * @example digitSum(12) = 3
+ * @example digitSum(9045) = 18
  */
 
-export const DigitSum = (num: number): number => {
+export const digitSum = (num: number): number => {
   if (num < 0 || !Number.isInteger(num)) {
     throw new Error("only natural numbers are supported");
   }

--- a/maths/factorial.ts
+++ b/maths/factorial.ts
@@ -1,16 +1,16 @@
 /**
- * @function Factorial
+ * @function factorial
  * @description Calculate the factorial of a natural number.
  * @param {number} num - A natural number.
  * @return {number} - The factorial.
- * @see https://en.wikipedia.org/wiki/Factorial
- * @example Factorial(0) = 1
- * @example Factorial(3) = 6
+ * @see https://en.wikipedia.org/wiki/factorial
+ * @example factorial(0) = 1
+ * @example factorial(3) = 6
  */
-export const Factorial = (num: number): number => {
+export const factorial = (num: number): number => {
   if (num < 0 || !Number.isInteger(num)) {
     throw new Error("only natural numbers are supported");
   }
 
-  return num === 0 ? 1 : num * Factorial(num - 1);
+  return num === 0 ? 1 : num * factorial(num - 1);
 };

--- a/maths/factors.ts
+++ b/maths/factors.ts
@@ -1,14 +1,14 @@
 /**
- * @function FindFactors
+ * @function findFactors
  * @description Find all the factors of a natural number.
  * @param {number} num - A natural number.
  * @return {Set<number>} - A set of all the factors of given natural number.
  * @see https://en.wikipedia.org/wiki/Divisor
- * @example FindFactors(1) = [1]
- * @example FindFactors(4) = [1,2,4]
- * @example FindFactors(16) = [1,3,5,15]
+ * @example findFactors(1) = [1]
+ * @example findFactors(4) = [1,2,4]
+ * @example findFactors(16) = [1,3,5,15]
  */
-export const FindFactors = (num: number): Set<number> => {
+export const findFactors = (num: number): Set<number> => {
     if (num <= 0 || !Number.isInteger(num)) {
         throw new Error("Only natural numbers are supported.");
     }

--- a/maths/find_min.ts
+++ b/maths/find_min.ts
@@ -1,15 +1,15 @@
 /**
- * @function FindMin
+ * @function findMin
  * @description Find the minimum in an array of numbers.
  * @param {Number[]} nums - An array of numbers.
  * @return {Number} - The minimum.
  * @see https://infinitbility.com/how-to-find-minimum-value-in-array-in-typescript/
- * @example FindMin([1,2,3,4,5]) = 1
- * @example FindMin([87,6,13,999]) = 6
- * @example FindMin([0.8,0.2,0.3,0.5]) = 0.2
- * @example FindMin([1,0.1,-1]) = -1
+ * @example findMin([1,2,3,4,5]) = 1
+ * @example findMin([87,6,13,999]) = 6
+ * @example findMin([0.8,0.2,0.3,0.5]) = 0.2
+ * @example findMin([1,0.1,-1]) = -1
  */
- export const FindMin = (nums: number[]): number => {
+ export const findMin = (nums: number[]): number => {
     if (nums.length === 0) {
       throw new Error("array must have length of 1 or greater");
     }

--- a/maths/greatest_common_factor.ts
+++ b/maths/greatest_common_factor.ts
@@ -1,5 +1,5 @@
 /**
- * @function GreatestCommonFactor
+ * @function greatestCommonFactor
  * @description Determine the greatest common factor of a group of numbers.
  * @param {Number[]} nums - An array of numbers.
  * @return {Number} - The greatest common factor.

--- a/maths/hamming_distance.ts
+++ b/maths/hamming_distance.ts
@@ -1,5 +1,5 @@
 /**
- * @function HammingDistance
+ * @function hammingDistance
  * @description Returns the Hamming distance between two strings of equal length
  * @summary The Hamming distance between two strings of equal length is the
  * number of positions at which the corresponding symbols are different. In other words,
@@ -10,9 +10,9 @@
  * @param str2 One of the strings to compare to the other
  * @returns {number}
  * @see [Wikipedia](https://en.wikipedia.org/wiki/Hamming_distance)
- * @example HammingDistance('happy', 'homie')
+ * @example hammingDistance('happy', 'homie')
  */
-const HammingDistance = (str1: string, str2: string) => {
+const hammingDistance = (str1: string, str2: string) => {
   if (str1.length !== str2.length) throw new Error('Strings must of the same length.')
 
   let dist = 0
@@ -22,4 +22,4 @@ const HammingDistance = (str1: string, str2: string) => {
   return dist
 }
 
-export { HammingDistance }
+export { hammingDistance }

--- a/maths/is_divisible.ts
+++ b/maths/is_divisible.ts
@@ -1,14 +1,14 @@
 /**
- * @function IsDivisible
+ * @function isDivisible
  * @description Checks is number is divisible by another number without remainder.
  * @param {number} num1 - first number, a dividend.
  * @param {number} num2 - second number, a divisor.
  * @return {boolean} - true if first number can be divided by second number without a remainder.
- * @example IsDivisible(10, 2) = true
- * @example IsDivisible(11, 3) = false
+ * @example isDivisible(10, 2) = true
+ * @example isDivisible(11, 3) = false
  */
 
-export const IsDivisible = (num1: number, num2: number): boolean => {
+export const isDivisible = (num1: number, num2: number): boolean => {
     if (num2 === 0) {
         throw new Error('Cannot divide by 0');
     }

--- a/maths/is_even.ts
+++ b/maths/is_even.ts
@@ -1,13 +1,13 @@
 /**
- * @function IsEven
+ * @function isEven
  * @description Determine whether a number is even.
  * @param {Number} num - A number.
  * @return {Boolean} - Whether the given number is even.
  * @see https://en.wikipedia.org/wiki/Parity_(mathematics)
- * @example IsEven(1) = false
- * @example IsEven(2) = true
+ * @example isEven(1) = false
+ * @example isEven(2) = true
  */
- export const IsEven = (num: number): boolean => {
+ export const isEven = (num: number): boolean => {
     if (!Number.isInteger(num)) {
       throw new Error("only integers can be even or odd");
     }

--- a/maths/is_leap_year.ts
+++ b/maths/is_leap_year.ts
@@ -1,15 +1,15 @@
 /**
- * @function IsLeapYear
+ * @function isLeapYear
  * @description Checks if a year is a leap year (Gregorian calendar).
  * A year is a leap year if it is divisible by 4 but not by 400 or if it is divisible by 400.
  * @param {number} year - A year, natural number > 0.
  * @return {boolean} - True if given year is a leap year.
  * @see https://en.wikipedia.org/wiki/Leap_year#Gregorian_calendar
- * @example IsLeapYear(2000) = true
- * @example IsLeapYear(2001) = false
+ * @example isLeapYear(2000) = true
+ * @example isLeapYear(2001) = false
  */
 
-export const IsLeapYear = (year: number): boolean => {
+export const isLeapYear = (year: number): boolean => {
   if (year <= 0 || !Number.isInteger(year)) {
     throw new Error("year must be a natural number > 0");
   }

--- a/maths/is_odd.ts
+++ b/maths/is_odd.ts
@@ -1,13 +1,13 @@
 /**
- * @function IsOdd
+ * @function isOdd
  * @description Determine whether a number is odd.
  * @param {Number} num - A number.
  * @return {Boolean} - Whether the given number is odd.
  * @see https://en.wikipedia.org/wiki/Parity_(mathematics)
- * @example IsOdd(1) = true
- * @example IsOdd(2) = false
+ * @example isOdd(1) = true
+ * @example isOdd(2) = false
  */
- export const IsOdd = (num: number): boolean => {
+ export const isOdd = (num: number): boolean => {
     if (!Number.isInteger(num)) {
       throw new Error("only integers can be even or odd");
     }

--- a/maths/is_palindrome.ts
+++ b/maths/is_palindrome.ts
@@ -6,7 +6,7 @@
  * @param number The input number.
  * @return {boolean} Wether the number is a Palindrome or not.
  */
-export const IsPalindrome = (number: number): boolean => {
+export const isPalindrome = (number: number): boolean => {
     if (number < 0 || (number % 10 === 0 && number !== 0)) {
         return false;
     }

--- a/maths/lowest_common_multiple.ts
+++ b/maths/lowest_common_multiple.ts
@@ -1,5 +1,5 @@
 /**
- * @function LowestCommonMultiple
+ * @function lowestCommonMultiple
  * @description Determine the lowest common multiple of a group of numbers.
  * @param {Number[]} nums - An array of numbers.
  * @return {Number} - The lowest common multiple.

--- a/maths/number_of_digits.ts
+++ b/maths/number_of_digits.ts
@@ -1,15 +1,15 @@
 /**
- * @function NumberOfDigits
+ * @function numberOfDigits
  * @description Calculate the number of digits of a natural number.
  * @param {number} num - A natural number.
  * @return {number} - Number of digits of given natural number.
  * @see https://math.stackexchange.com/a/231745/518862
- * @example NumberOfDigits(18) = 2
- * @example NumberOfDigits(294568) = 6
- * @example NumberOfDigits(128798319794) = 12
+ * @example numberOfDigits(18) = 2
+ * @example numberOfDigits(294568) = 6
+ * @example numberOfDigits(128798319794) = 12
  */
 
-export const NumberOfDigits = (num: number): number => {
+export const numberOfDigits = (num: number): number => {
   if (num <= 0 || !Number.isInteger(num)) {
     throw new Error("only natural numbers are supported");
   }

--- a/maths/perfect_square.ts
+++ b/maths/perfect_square.ts
@@ -6,6 +6,6 @@
  * @param {num} number
  */
 
-export const PerfectSquare = (num: number) => {
+export const perfectSquare = (num: number) => {
   return Number.isInteger(Math.sqrt(num));
 };

--- a/maths/pronic_number.ts
+++ b/maths/pronic_number.ts
@@ -1,5 +1,5 @@
 /**
- * @function PronicNumber
+ * @function pronicNumber
  * @description Checks whether a given number is a pronic number or not
  * @summary Pronic numbers, or oblong numbers as they are often referred to as,
  * are numbers which are the product of two consecutive integers. That is,
@@ -9,11 +9,11 @@
  * @param num The number to check for being pronic
  * @returns {boolean} Whether the number is pronic or not
  * @see [Wikipedia](https://en.wikipedia.org/wiki/Pronic_number)
- * @example PronicNumber(20) = true
- * @example PronicNumber(30) = true
- * @example PronicNumber(49) = false
+ * @example pronicNumber(20) = true
+ * @example pronicNumber(30) = true
+ * @example pronicNumber(49) = false
  */
-const PronicNumber = (n: number) => {
+const pronicNumber = (n: number) => {
   if (isNaN(n)) throw new Error('The input needs to be a number')
   if (!Number.isInteger(n) || n < 0) throw new Error('The input needs to be a non-negative integer')
   if (n === 0) return true
@@ -21,4 +21,4 @@ const PronicNumber = (n: number) => {
   return !Number.isInteger(Math.sqrt(n)) && Math.floor(Math.sqrt(n)) * Math.ceil(Math.sqrt(n)) === n
 }
 
-export { PronicNumber }
+export { pronicNumber }

--- a/maths/sieve_of_eratosthenes.ts
+++ b/maths/sieve_of_eratosthenes.ts
@@ -1,14 +1,14 @@
 /**
- * @function  SieveOfEratosthenes
+ * @function sieveOfEratosthenes
  * @description Find the prime numbers between 2 and n 
  * @param {number} n - numbers set the limit that the algorithm needs to look to find the primes
  * @return {number[]} - List of prime numbers
  * @see https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes\
- * @example SieveOfErastosthenes(5) = [2,3,5] 
- * @example SieveOfErastosthenes(10) = [2,3,5,7]
+ * @example sieveOfEratosthenes(5) = [2,3,5] 
+ * @example sieveOfEratosthenes(10) = [2,3,5,7]
  */
 
-export function SieveOfEratosthenes(n: number): number[] {
+export function sieveOfEratosthenes(n: number): number[] {
   if (n < 0 || !Number.isInteger(n)) {
     throw new Error("Only natural numbers are supported");
   }

--- a/maths/signum.ts
+++ b/maths/signum.ts
@@ -1,5 +1,5 @@
 /**
- * @function Signum
+ * @function signum
  * @description Returns the sign of a number
  * @summary The signum function is an odd mathematical function, which returns the 
  * sign of the provided real number.
@@ -8,12 +8,12 @@
  * @param {Number} input
  * @returns {-1 | 0 | 1 | NaN} sign of input (and NaN if the input is not a number)
  * @see [Wikipedia](https://en.wikipedia.org/wiki/Sign_function)
- * @example Signum(10) = 1
- * @example Signum(0) = 0
- * @example Signum(-69) = -1
- * @example Signum("hello world") = NaN
+ * @example signum(10) = 1
+ * @example signum(0) = 0
+ * @example signum(-69) = -1
+ * @example signum("hello world") = NaN
  */
-export const Signum = (num: number) => {
+export const signum = (num: number) => {
   if (num === 0) return 0
   if (num > 0) return 1
   if (num < 0) return -1

--- a/maths/test/absolute_value.test.ts
+++ b/maths/test/absolute_value.test.ts
@@ -1,28 +1,28 @@
-import { AbsoluteValue } from "../absolute_value";
+import { absoluteValue } from "../absolute_value";
 
-describe("AbsoluteValue", () => {
+describe("absoluteValue", () => {
   it("should return the absolute value of zero", () => {
-    const absoluteValueOfZero = AbsoluteValue(0);
+    const absoluteValueOfZero = absoluteValue(0);
     expect(absoluteValueOfZero).toBe(0);
   });
 
   it("should return the absolute value of a negative integer", () => {
-    const absoluteValueOfNegativeInteger = AbsoluteValue(-34);
+    const absoluteValueOfNegativeInteger = absoluteValue(-34);
     expect(absoluteValueOfNegativeInteger).toBe(34);
   });
 
   it("should return the absolute value of a positive integer", () => {
-    const absoluteValueOfPositiveInteger = AbsoluteValue(50);
+    const absoluteValueOfPositiveInteger = absoluteValue(50);
     expect(absoluteValueOfPositiveInteger).toBe(50);
   });
 
   it("should return the absolute value of a positive floating number", () => {
-    const absoluteValueOfPositiveFloating = AbsoluteValue(20.2034);
+    const absoluteValueOfPositiveFloating = absoluteValue(20.2034);
     expect(absoluteValueOfPositiveFloating).toBe(20.2034);
   });
 
   it("should return the absolute value of a negative floating number", () => {
-    const absoluteValueOfNegativeFloating = AbsoluteValue(-20.2034);
+    const absoluteValueOfNegativeFloating = absoluteValue(-20.2034);
     expect(absoluteValueOfNegativeFloating).toBe(20.2034);
   });
 });

--- a/maths/test/aliquot_sum.test.ts
+++ b/maths/test/aliquot_sum.test.ts
@@ -1,5 +1,5 @@
-import { AliquotSum } from "../aliquot_sum";
+import { aliquotSum } from "../aliquot_sum";
 
 test.each([[15, 9], [18, 21], [28, 28], [100, 117], [169, 14], [1729, 511], [15625, 3906]])("Aliquot Sum of %i is %i", (num, expected) => {
-  expect(AliquotSum(num)).toBe(expected)
+  expect(aliquotSum(num)).toBe(expected)
 })

--- a/maths/test/armstrong_number.test.ts
+++ b/maths/test/armstrong_number.test.ts
@@ -1,5 +1,5 @@
-import { ArmstrongNumber } from "../armstrong_number"
+import { armstrongNumber } from "../armstrong_number"
 
 test.each([[9, true], [-310, false], [0, false], [407, true], [420, false], [92727, true], [13579, false]])('i is an Armstrong number or not', (num, expected) => {
-  expect(ArmstrongNumber(num)).toBe(expected)
+  expect(armstrongNumber(num)).toBe(expected)
 })

--- a/maths/test/binary_convert.test.ts
+++ b/maths/test/binary_convert.test.ts
@@ -1,22 +1,22 @@
-import { BinaryConvert } from '../binary_convert'
+import { binaryConvert } from '../binary_convert'
 
-describe('BinaryConvert', () => {
+describe('binaryConvert', () => {
   it('should return the correct value', () => {
-    expect(BinaryConvert(4)).toBe('100')
+    expect(binaryConvert(4)).toBe('100')
   })
   it('should return the correct value', () => {
-    expect(BinaryConvert(12)).toBe('1100')
+    expect(binaryConvert(12)).toBe('1100')
   })
   it('should return the correct value of the sum from two number', () => {
-    expect(BinaryConvert(12 + 2)).toBe('1110')
+    expect(binaryConvert(12 + 2)).toBe('1110')
   })
   it('should return the correct value of the subtract from two number', () => {
-    expect(BinaryConvert(245 - 56)).toBe('10111101')
+    expect(binaryConvert(245 - 56)).toBe('10111101')
   })
   it('should return the correct value', () => {
-    expect(BinaryConvert(254)).toBe('11111110')
+    expect(binaryConvert(254)).toBe('11111110')
   })
   it('should return the correct value', () => {
-    expect(BinaryConvert(63483)).toBe('1111011111111011')
+    expect(binaryConvert(63483)).toBe('1111011111111011')
   })
 })

--- a/maths/test/binomial_coefficient.test.ts
+++ b/maths/test/binomial_coefficient.test.ts
@@ -1,6 +1,6 @@
-import { BinomialCoefficient } from '../binomial_coefficient'; 
+import { binomialCoefficient } from '../binomial_coefficient'; 
 
-describe('BinomialCoefficient', () => {
+describe('binomialCoefficient', () => {
     it('should calculate the correct binomial coefficient', () => {
         // Test cases with expected results
         const testCases: [number, number, number][] = [
@@ -14,7 +14,7 @@ describe('BinomialCoefficient', () => {
 
         // Iterate through each test case and verify the result
         testCases.forEach(([n, k, expected]) => {
-            const result = BinomialCoefficient(n, k);
+            const result = binomialCoefficient(n, k);
             expect(result).toEqual(expected);
         });
     });
@@ -27,7 +27,7 @@ describe('BinomialCoefficient', () => {
         ];
 
         invalidCases.forEach(([n, k]) => {
-            const result = BinomialCoefficient(n, k);
+            const result = binomialCoefficient(n, k);
             expect(result).toEqual(0);
         });
     });

--- a/maths/test/digit_sum.test.ts
+++ b/maths/test/digit_sum.test.ts
@@ -1,10 +1,10 @@
-import { DigitSum } from "../digit_sum";
+import { digitSum } from "../digit_sum";
 
-describe("DigitSum", () => {
+describe("digitSum", () => {
   test.each([-42, -0.1, -1, 0.2, 3.3, NaN, -Infinity, Infinity])(
     "should throw an error for non natural number %d",
     (num) => {
-      expect(() => DigitSum(num)).toThrowError(
+      expect(() => digitSum(num)).toThrowError(
         "only natural numbers are supported",
       );
     },
@@ -13,7 +13,7 @@ describe("DigitSum", () => {
   test.each([[0,0], [1, 1], [12, 3], [123, 6], [9045, 18], [1234567890, 45]])(
     "of %i should be %i",
     (num, expected) => {
-      expect(DigitSum(num)).toBe(expected);
+      expect(digitSum(num)).toBe(expected);
     },
   );
 });

--- a/maths/test/factorial.test.ts
+++ b/maths/test/factorial.test.ts
@@ -1,10 +1,10 @@
-import { Factorial } from "../factorial";
+import { factorial } from "../factorial";
 
-describe("Factorial", () => {
+describe("factorial", () => {
   test.each([-0.1, -1, -2, -42, 0.01, 0.42, 0.5, 1.337])(
     "should throw an error for non natural number %d",
     (num) => {
-      expect(() => Factorial(num)).toThrowError(
+      expect(() => factorial(num)).toThrowError(
         "only natural numbers are supported",
       );
     },
@@ -13,11 +13,11 @@ describe("Factorial", () => {
   test.each([[1, 1], [3, 6], [5, 120], [10, 3628800]])(
     "of %i should be %i",
     (num, expected) => {
-      expect(Factorial(num)).toBe(expected);
+      expect(factorial(num)).toBe(expected);
     },
   );
 
   test("of 1 should be 0 by definition", () => {
-    expect(Factorial(0)).toBe(1);
+    expect(factorial(0)).toBe(1);
   });
 });

--- a/maths/test/factors.test.ts
+++ b/maths/test/factors.test.ts
@@ -1,10 +1,10 @@
-import { FindFactors } from "../factors";
+import { findFactors } from "../factors";
 
-describe("FindFactors", () => {
+describe("findFactors", () => {
     test.each([-890, -5.56, -7, 0, 0.73, 4.2, NaN, -Infinity, Infinity])(
         "should throw an error for non natural number %d",
         (num) => {
-            expect(() => FindFactors(num)).toThrowError(
+            expect(() => findFactors(num)).toThrowError(
                 "Only natural numbers are supported."
             );
         }
@@ -19,7 +19,7 @@ describe("FindFactors", () => {
     ])(
         "of %i should return the correct set of its factors",
         (num, expected) => {
-            expect(FindFactors(num)).toStrictEqual(expected);
+            expect(findFactors(num)).toStrictEqual(expected);
         }
     );
 });

--- a/maths/test/find_min.test.ts
+++ b/maths/test/find_min.test.ts
@@ -1,15 +1,15 @@
-import { FindMin } from "../find_min";
+import { findMin } from "../find_min";
 
-describe("FindMin", () => {
+describe("findMin", () => {
   test.each([[[1,2,3,4,5,6], 1], [[87,6,13,999], 6], [[0.8,0.2,0.3,0.5], 0.2], [[1,0.1,-1], -1]])(
     "of this array should be %i",
     (nums, expected) => {
-      expect(FindMin(nums)).toBe(expected);
+      expect(findMin(nums)).toBe(expected);
     },
   );
 
   test("of arrays with length 0 should error", () => {
-    expect(() => FindMin([])).toThrowError(
+    expect(() => findMin([])).toThrowError(
       "array must have length of 1 or greater",
     );
   });

--- a/maths/test/hamming_distance.test.ts
+++ b/maths/test/hamming_distance.test.ts
@@ -1,5 +1,5 @@
-import { HammingDistance } from "../hamming_distance"
+import { hammingDistance } from "../hamming_distance"
 
 test.each([['happy', 'homie', 4], ['hole', 'home', 1], ['cathrine', 'caroline', 3], ['happiness', 'dizziness', 4]])('Hamming Distance', (str1, str2, result) => {
-  expect(HammingDistance(str1, str2)).toBe(result)
+  expect(hammingDistance(str1, str2)).toBe(result)
 })

--- a/maths/test/is_divisible.test.ts
+++ b/maths/test/is_divisible.test.ts
@@ -1,6 +1,6 @@
-import { IsDivisible } from "../is_divisible";
+import { isDivisible } from "../is_divisible";
 
-describe("IsDivisible", () => {
+describe("isDivisible", () => {
     test.each([
         [1, 1],
         [6, 3],
@@ -14,7 +14,7 @@ describe("IsDivisible", () => {
     ])(
         "%f is divisible by %f",
         (num1, num2) => {
-            expect(IsDivisible(num1, num2)).toBe(true);
+            expect(isDivisible(num1, num2)).toBe(true);
         },
     );
 
@@ -31,11 +31,11 @@ describe("IsDivisible", () => {
     ])(
         "%f is not divisible by %f",
         (num1, num2) => {
-            expect(IsDivisible(num1, num2)).toBe(false);
+            expect(isDivisible(num1, num2)).toBe(false);
         },
     );
 
     test("should not divide by 0", () => {
-        expect(() => IsDivisible(10, 0)).toThrow();
+        expect(() => isDivisible(10, 0)).toThrow();
     });
 });

--- a/maths/test/is_even.test.ts
+++ b/maths/test/is_even.test.ts
@@ -1,15 +1,15 @@
-import { IsEven } from "../is_even";
+import { isEven } from "../is_even";
 
-describe("IsEven", () => {
+describe("isEven", () => {
   test.each([[2, true], [1, false], [0, true], [-1, false], [-2, true]])(
     "correct output for for %i",
     (nums, expected) => {
-      expect(IsEven(nums)).toBe(expected);
+      expect(isEven(nums)).toBe(expected);
     },
   );
 
   test("only whole numbers should be accepted", () => {
-    expect(() => IsEven(0.5)).toThrowError(
+    expect(() => isEven(0.5)).toThrowError(
       "only integers can be even or odd",
     );
   });

--- a/maths/test/is_leap_year.test.ts
+++ b/maths/test/is_leap_year.test.ts
@@ -1,12 +1,12 @@
-import { IsLeapYear } from "../is_leap_year";
+import { isLeapYear } from "../is_leap_year";
 
-describe("IsLeapYear", () => {
+describe("isLeapYear", () => {
   test.each([4, 8, 12, 2004])(
     "a year is a leap year it is divisible by 4 but not by 400 like %i",
     (year) => {
       expect(year % 4 === 0).toBe(true);
       expect(year % 400 === 0).toBe(false);
-      expect(IsLeapYear(year)).toBe(true);
+      expect(isLeapYear(year)).toBe(true);
     },
   );
 
@@ -14,7 +14,7 @@ describe("IsLeapYear", () => {
     "a year is a leap year it is divisible by 400 like %i",
     (year) => {
       expect(year % 400 === 0).toBe(true);
-      expect(IsLeapYear(year)).toBe(true);
+      expect(isLeapYear(year)).toBe(true);
     },
   );
 
@@ -22,7 +22,7 @@ describe("IsLeapYear", () => {
     "a year is not a leap year if it is not divisible by 4 like %i",
     (year) => {
       expect(year % 4 === 0).toBe(false);
-      expect(IsLeapYear(year)).toBe(false);
+      expect(isLeapYear(year)).toBe(false);
     },
   );
 
@@ -31,7 +31,7 @@ describe("IsLeapYear", () => {
     (year) => {
       expect(year % 100 === 0).toBe(true);
       expect(year % 400 === 0).toBe(false);
-      expect(IsLeapYear(year)).toBe(false);
+      expect(isLeapYear(year)).toBe(false);
     },
   );
 
@@ -40,7 +40,7 @@ describe("IsLeapYear", () => {
     (year) => {
       expect(year > 0).toBe(true);
       expect(Number.isInteger(year)).toBe(true);
-      expect(() => IsLeapYear(year)).not.toThrow();
+      expect(() => isLeapYear(year)).not.toThrow();
     },
   );
 
@@ -48,7 +48,7 @@ describe("IsLeapYear", () => {
     "a year is not supported if it is negative like %i",
     (year) => {
       expect(year < 0).toBe(true);
-      expect(() => IsLeapYear(year)).toThrow("year must be a natural number > 0");
+      expect(() => isLeapYear(year)).toThrow("year must be a natural number > 0");
     },
   );
 
@@ -56,11 +56,11 @@ describe("IsLeapYear", () => {
     "a year is not supported if it is not an integer %d",
     (year) => {
       expect(Number.isInteger(year)).toBe(false);
-      expect(() => IsLeapYear(year)).toThrow("year must be a natural number > 0");
+      expect(() => isLeapYear(year)).toThrow("year must be a natural number > 0");
     },
   );
 
   test("a year is not supported if it is 0", () => {
-    expect(() => IsLeapYear(0)).toThrow("year must be a natural number > 0");
+    expect(() => isLeapYear(0)).toThrow("year must be a natural number > 0");
   })
 });

--- a/maths/test/is_odd.test.ts
+++ b/maths/test/is_odd.test.ts
@@ -1,15 +1,15 @@
-import { IsOdd } from "../is_odd";
+import { isOdd } from "../is_odd";
 
-describe("IsOdd", () => {
+describe("isOdd", () => {
   test.each([[2, false], [1, true], [0, false], [-1, true], [-2, false]])(
     "correct output for for %i",
     (nums, expected) => {
-      expect(IsOdd(nums)).toBe(expected);
+      expect(isOdd(nums)).toBe(expected);
     },
   );
 
   test("only whole numbers should be accepted", () => {
-    expect(() => IsOdd(0.5)).toThrowError(
+    expect(() => isOdd(0.5)).toThrowError(
       "only integers can be even or odd",
     );
   });

--- a/maths/test/is_palindrome.test.ts
+++ b/maths/test/is_palindrome.test.ts
@@ -1,10 +1,10 @@
-import { IsPalindrome } from "../is_palindrome";
+import { isPalindrome } from "../is_palindrome";
 
-describe("IsPalindrome", () => {
+describe("isPalindrome", () => {
   test.each([[5, true], [1234, false], [12321, true], [31343, false]])(
     "correct output for %i",
     (nums, expected) => {
-        expect(IsPalindrome(nums)).toBe(expected);
+        expect(isPalindrome(nums)).toBe(expected);
       },
   );
 });

--- a/maths/test/number_of_digits.test.ts
+++ b/maths/test/number_of_digits.test.ts
@@ -1,10 +1,10 @@
-import { NumberOfDigits } from "../number_of_digits";
+import { numberOfDigits } from "../number_of_digits";
 
-describe("NumberOfDigits", () => {
+describe("numberOfDigits", () => {
   test.each([-890, -5.56, -7, 0, 0.73, 4.2, NaN, -Infinity, Infinity])(
     "should throw an error for non natural number %d",
     (num) => {
-      expect(() => NumberOfDigits(num)).toThrowError(
+      expect(() => numberOfDigits(num)).toThrowError(
         "only natural numbers are supported",
       );
     },
@@ -13,7 +13,7 @@ describe("NumberOfDigits", () => {
   test.each([[1, 1], [18, 2], [549, 3], [7293, 4], [1234567890, 10]])(
     "of %i should be %i",
     (num, expected) => {
-      expect(NumberOfDigits(num)).toBe(expected);
+      expect(numberOfDigits(num)).toBe(expected);
     },
   );
 });

--- a/maths/test/perfect_square.test.ts
+++ b/maths/test/perfect_square.test.ts
@@ -1,9 +1,9 @@
-import { PerfectSquare } from "../perfect_square";
+import { perfectSquare } from "../perfect_square";
 
 test("Check perfect square", () => {
-    expect(PerfectSquare(16)).toBe(true);
-    expect(PerfectSquare(12)).toBe(false);
-    expect(PerfectSquare(19)).toBe(false);
-    expect(PerfectSquare(25)).toBe(true);
-    expect(PerfectSquare(42)).toBe(false);
+    expect(perfectSquare(16)).toBe(true);
+    expect(perfectSquare(12)).toBe(false);
+    expect(perfectSquare(19)).toBe(false);
+    expect(perfectSquare(25)).toBe(true);
+    expect(perfectSquare(42)).toBe(false);
 });

--- a/maths/test/pronic_number.test.ts
+++ b/maths/test/pronic_number.test.ts
@@ -1,5 +1,5 @@
-import { PronicNumber } from '../pronic_number'
+import { pronicNumber } from '../pronic_number'
 
 test.each([[0, true], [10, false], [30, true], [69, false], [420, true]])('Pronic Number', (number, result) => {
-  expect(PronicNumber(number)).toBe(result)
+  expect(pronicNumber(number)).toBe(result)
 })

--- a/maths/test/radians_to_degrees.test.ts
+++ b/maths/test/radians_to_degrees.test.ts
@@ -1,4 +1,4 @@
-import {radiansToDegrees} from '../radians_to_degrees'; 
+import { radiansToDegrees } from '../radians_to_degrees'; 
   
 test("RadiansToDegrees", () => {
   expect(radiansToDegrees(0)).toBe(0);

--- a/maths/test/sieve_of_eratosthenes.test.ts
+++ b/maths/test/sieve_of_eratosthenes.test.ts
@@ -1,11 +1,11 @@
-import { SieveOfEratosthenes } from "../sieve_of_eratosthenes";
+import { sieveOfEratosthenes } from "../sieve_of_eratosthenes";
 
 
 describe("Sieve of Eratosthenes", () => {
   test.each([-2, 0.1, -0.01, 2.2])(
     "should throw a error for non natural number",
     (n) => {
-      expect(() => SieveOfEratosthenes(n)).toThrow(
+      expect(() => sieveOfEratosthenes(n)).toThrow(
         "Only natural numbers are supported"
       );
     },
@@ -14,7 +14,7 @@ describe("Sieve of Eratosthenes", () => {
   test.each([[5, [2, 3, 5]], [11, [2, 3, 5, 7, 11]], [30, [2, 3, 5, 7, 11, 13, 17, 19, 23, 29]]])(
     "of %i should be %o",
     (num, expected) => {
-      expect(SieveOfEratosthenes(num)).toStrictEqual(expected);
+      expect(sieveOfEratosthenes(num)).toStrictEqual(expected);
     },
   );
 });

--- a/maths/test/signum.test.ts
+++ b/maths/test/signum.test.ts
@@ -1,5 +1,5 @@
-import { Signum } from "../signum";
+import { signum } from "../signum";
 
 test.each([[10, 1], [0, 0], [-69, -1], [NaN, NaN]])("The sign of %i is %i", (num, expected) => {
-  expect(Signum(num)).toBe(expected)
+  expect(signum(num)).toBe(expected)
 })

--- a/maths/test/ugly_numbers.test.ts
+++ b/maths/test/ugly_numbers.test.ts
@@ -1,6 +1,6 @@
-import { UglyNumbers } from '../ugly_numbers';
+import { uglyNumbers } from '../ugly_numbers';
 
 test('Ugly Numbers', () => {
-  const uglyNumbers = UglyNumbers();
-  expect(Array(11).fill(undefined).map(() => uglyNumbers.next().value)).toEqual([1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 15]);
+  const uglyNums = uglyNumbers();
+  expect(Array(11).fill(undefined).map(() => uglyNums.next().value)).toEqual([1, 2, 3, 4, 5, 6, 8, 9, 10, 12, 15]);
 })

--- a/maths/test/zellers_congruence.test.ts
+++ b/maths/test/zellers_congruence.test.ts
@@ -1,4 +1,4 @@
-import { Calendar, GetWeekday } from "../zellers_congruence";
+import { Calendar, getWeekday } from "../zellers_congruence";
 
 describe("Zeller's congruence", () => {
   test.each([
@@ -23,7 +23,7 @@ describe("Zeller's congruence", () => {
   ])(
     `The weekday of $year-$month-$day in the default calendar is $expected`,
     ({ year, month, day, expected }) => {
-      expect(GetWeekday(year, month, day)).toEqual(expected);
+      expect(getWeekday(year, month, day)).toEqual(expected);
     }
   );
 
@@ -47,12 +47,12 @@ describe("Zeller's congruence", () => {
   ])(
     `The weekday of $year-$month-$day in the Julian calendar is $expected`,
     ({ year, month, day, expected }) => {
-      expect(GetWeekday(year, month, day, Calendar.Julian)).toEqual(expected);
+      expect(getWeekday(year, month, day, Calendar.Julian)).toEqual(expected);
     }
   );
 
   test(`The default calendar is Gregorian`, () => {
-    expect(GetWeekday(1, 1, 1)).toEqual(1);
+    expect(getWeekday(1, 1, 1)).toEqual(1);
   });
 
   test.each([
@@ -70,7 +70,7 @@ describe("Zeller's congruence", () => {
       const dateString = `${year.toString().padStart(4, "0")}-${month
         .toString()
         .padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
-      expect(GetWeekday(year, month, day)).toEqual(
+      expect(getWeekday(year, month, day)).toEqual(
         new Date(dateString).getUTCDay()
       );
     }
@@ -81,7 +81,7 @@ describe("Zeller's congruence", () => {
     { year: -5, month: 1, day: 1 },
     { year: 12.2, month: 1, day: 1 },
   ])(`Should throw an error for invalid year $year`, ({ year, month, day }) => {
-    expect(() => GetWeekday(year, month, day)).toThrow(
+    expect(() => getWeekday(year, month, day)).toThrow(
       "Year must be an integer greater than 0"
     );
   });
@@ -94,7 +94,7 @@ describe("Zeller's congruence", () => {
   ])(
     `Should throw an error for invalid month $month`,
     ({ year, month, day }) => {
-      expect(() => GetWeekday(year, month, day)).toThrow(
+      expect(() => getWeekday(year, month, day)).toThrow(
         "Month must be an integer between 1 and 12"
       );
     }
@@ -105,7 +105,7 @@ describe("Zeller's congruence", () => {
     { year: 2001, month: 1, day: 0 },
     { year: 2001, month: 1, day: 32 },
   ])(`Should throw an error for invalid day $day`, ({ year, month, day }) => {
-    expect(() => GetWeekday(year, month, day)).toThrow(
+    expect(() => getWeekday(year, month, day)).toThrow(
       "Day must be an integer between 1 and 31"
     );
   });

--- a/maths/ugly_numbers.ts
+++ b/maths/ugly_numbers.ts
@@ -9,18 +9,18 @@
  * For the provided n, the nth ugly number shall be computed.
  * @see [GeeksForGeeks](https://www.geeksforgeeks.org/ugly-numbers/)
  */
-function* UglyNumbers() {
+function* uglyNums(): Generator<number, void, unknown> {
   yield 1
 
   let idx2 = 0, idx3 = 0, idx5 = 0
-  const uglyNumbers = [1]
+  const uglyNums = [1]
 
   let nextx2: number, nextx3: number, nextx5: number, nextUglyNum: number
 
   while(true) {
-    nextx2 = uglyNumbers[idx2] * 2
-    nextx3 = uglyNumbers[idx3] * 3
-    nextx5 = uglyNumbers[idx5] * 5
+    nextx2 = uglyNums[idx2] * 2
+    nextx3 = uglyNums[idx3] * 3
+    nextx5 = uglyNums[idx5] * 5
 
     nextUglyNum = Math.min(nextx2, nextx3, nextx5)
     yield nextUglyNum
@@ -29,8 +29,8 @@ function* UglyNumbers() {
     if(nextx3 === nextUglyNum) idx3++
     if(nextx5 === nextUglyNum) idx5++
     
-    uglyNumbers.push(nextUglyNum)
+    uglyNums.push(nextUglyNum)
   }
 }
 
-export { UglyNumbers }
+export { uglyNums }

--- a/maths/ugly_numbers.ts
+++ b/maths/ugly_numbers.ts
@@ -9,7 +9,7 @@
  * For the provided n, the nth ugly number shall be computed.
  * @see [GeeksForGeeks](https://www.geeksforgeeks.org/ugly-numbers/)
  */
-function* uglyNums(): Generator<number, void, unknown> {
+function* uglyNumbers(): Generator<number, void, unknown> {
   yield 1
 
   let idx2 = 0, idx3 = 0, idx5 = 0
@@ -33,4 +33,4 @@ function* uglyNums(): Generator<number, void, unknown> {
   }
 }
 
-export { uglyNums }
+export { uglyNumbers }

--- a/maths/zellers_congruence.ts
+++ b/maths/zellers_congruence.ts
@@ -4,17 +4,17 @@ export enum Calendar {
 }
 
 /**
- * @function GetWeekday
+ * @function getWeekday
  * @description Calculate the day of the week for any Julian or Gregorian calendar date.
  * @param {number} year - Year with century.
  * @param {number} month - Month of the year (1-12).
  * @param {number} day - Day of the month (1-31).
  * @return {number} Day of the week, where 0 represents Sunday.
  * @see https://en.wikipedia.org/wiki/Zeller's_congruence
- * @example GetWeekday(2000, 1, 1) = 6
- * @example GetWeekday(1500, 1, 1, Calendar.Julian) = 3
+ * @example getWeekday(2000, 1, 1) = 6
+ * @example getWeekday(1500, 1, 1, Calendar.Julian) = 3
  */
-export const GetWeekday = (
+export const getWeekday = (
   year: number,
   month: number,
   day: number,


### PR DESCRIPTION
Updated existing functions in `maths/` to follow the `lowerCamelCase` naming convention.