### PR TITLE
tests: add missing tests of `isPalindrome`

### DIFF
--- a/maths/test/is_palindrome.test.ts
+++ b/maths/test/is_palindrome.test.ts
@@ -1,7 +1,7 @@
 import { isPalindrome } from "../is_palindrome";
 
 describe("isPalindrome", () => {
-  test.each([[5, true], [1234, false], [12321, true], [31343, false]])(
+  test.each([[0, true], [1, true], [5, true], [1234, false], [12321, true], [31343, false], [-1, false], [-11, false], [10, false]])(
     "correct output for %i",
     (nums, expected) => {
         expect(isPalindrome(nums)).toBe(expected);


### PR DESCRIPTION
This PR adds tests covering this line:
https://github.com/TheAlgorithms/TypeScript/blob/296e4a5af4bf4dc3a921db96bd95e82112d0bb38/maths/is_palindrome.ts#L11
