### PR TITLE
fix: handle squares properly in `isSquareFree`

### DIFF
--- a/maths/is_square_free.ts
+++ b/maths/is_square_free.ts
@@ -14,7 +14,7 @@ export const isSquareFree = (n: number): boolean => {
     if (n % 2 === 0) n = n / 2;
     if (n % 2 === 0) return false;
 
-    for (let i: number = 3; i < Math.sqrt(n); i = i + 2) {
+    for (let i: number = 3; i <= Math.sqrt(n); i = i + 2) {
         if (n % i === 0) {
             n = n / i;
             if (n % i === 0) return false;

--- a/maths/test/is_square_free.test.ts
+++ b/maths/test/is_square_free.test.ts
@@ -1,11 +1,14 @@
 import { isSquareFree } from '../is_square_free';
 
 describe('isSquareFree', () => {
-    test('should return correct boolean value', () => {
-        expect(isSquareFree(1)).toBe(true);
-        expect(isSquareFree(10)).toBe(true);
-        expect(isSquareFree(20)).toBe(false);
-        expect(isSquareFree(26)).toBe(true);
-        expect(isSquareFree(48)).toBe(false);
+  test.each([1, 2, 3, 5, 7, 10, 26, 2*3, 3*5*7, 11*13*17*19])(
+    "%i is square free",
+    (input) => {
+      expect(isSquareFree(input)).toBe(true);
+    });
+  test.each([20, 48, 2*7*7, 2*3*3, 5*5*7, 2*3*13*13*17, 4*4*4, 2*2, 3*3, 5*5, 100, 0])(
+    "%i is not square free",
+    (input) => {
+      expect(isSquareFree(input)).toBe(false);
     });
 });


### PR DESCRIPTION
The current implementation of [`isSquarefFree`](https://github.com/TheAlgorithms/TypeScript/blob/4f6cd6c264d047dcc1bf1045765f4d8968fee6d2/maths/is_square_free.ts#L11) returns `true` for `9 = 3*3`. This PR fixes that and adds missing tests and reorganizes them.