### PR TITLE
style: use `const` when possible

### DIFF
--- a/backtracking/all_combinations_of_size_k.ts
+++ b/backtracking/all_combinations_of_size_k.ts
@@ -10,8 +10,8 @@
  *   and repeat the same process for the next number.
  */
 export function generateCombinations(n: number, k: number): number[][] {
-  let combinationsAcc: number[][] = [];
-  let currentCombination: number[] = [];
+  const combinationsAcc: number[][] = [];
+  const currentCombination: number[] = [];
 
   function generateAllCombos(
     n: number,

--- a/bit_manipulation/add_binary.ts
+++ b/bit_manipulation/add_binary.ts
@@ -8,7 +8,7 @@
 export function addBinary(firstBinaryNo: string, secondBinaryNo: string): string {
     let lengthOfFirstNumber: number = firstBinaryNo.length - 1;
     let lengthOfSecondNumber: number = secondBinaryNo.length - 1;
-    let solution: string[] = [];
+    const solution: string[] = [];
     let carry: number = 0;
 
     while ( lengthOfFirstNumber >= 0 || lengthOfSecondNumber >= 0) {

--- a/data_structures/heap/heap.ts
+++ b/data_structures/heap/heap.ts
@@ -50,7 +50,7 @@ export abstract class Heap<T> {
   }
 
   public extract(): T {
-    let maxElement = this.heap[0];
+    const maxElement = this.heap[0];
     this.heap[0] = this.heap[this.size() - 1];
     this.heap.pop();
     this.sinkDown();
@@ -162,8 +162,8 @@ export class PriorityQueue<T> extends MinHeap<T> {
   }
 
   protected swap(a: number, b: number) {
-    let akey = this.keys_index(this.heap[a]);
-    let bkey = this.keys_index(this.heap[b]);
+    const akey = this.keys_index(this.heap[a]);
+    const bkey = this.keys_index(this.heap[b]);
     [this.keys[akey], this.keys[bkey]] = [this.keys[bkey], this.keys[akey]];
     super.swap(a, b);
   }
@@ -188,7 +188,7 @@ export class PriorityQueue<T> extends MinHeap<T> {
       this.insert(value);
       return;
     }
-    let key = this.keys[idx];
+    const key = this.keys[idx];
     if (this.compare(this.heap[key], value)) {
       // Do not do anything if the value in the heap already has a higher priority.
       return;

--- a/data_structures/heap/test/heap.test.ts
+++ b/data_structures/heap/test/heap.test.ts
@@ -8,7 +8,7 @@ describe("MaxHeap", () => {
 
   beforeEach(() => {
     heap = new MaxHeap();
-    for (let element of elements) {
+    for (const element of elements) {
       heap.insert(element);
     }
   });
@@ -61,7 +61,7 @@ describe("MinHeap", () => {
 
   beforeEach(() => {
     heap = new MinHeap();
-    for (let element of elements) {
+    for (const element of elements) {
       heap.insert(element);
     }
   });
@@ -106,7 +106,7 @@ describe("MinHeap", () => {
   });
 
   it("should increase priority", () => {
-    let heap = new PriorityQueue((a: number) => { return a; }, elements.length);
+    const heap = new PriorityQueue((a: number) => { return a; }, elements.length);
     elements.forEach((element: number) => {
       heap.insert(element);
     });

--- a/data_structures/queue/linked_queue.ts
+++ b/data_structures/queue/linked_queue.ts
@@ -55,7 +55,7 @@ export class LinkedQueue<T> implements Queue<T> {
         }
 
         this.size--;
-        let head = this.head; // We store the head in order not to lose track of it
+        const head = this.head; // We store the head in order not to lose track of it
         this.head = this.head.next; // Update the the head to the next node
         return head.value; // Return the value of the head
     }

--- a/data_structures/stack/test/linked_list_stack.test.ts
+++ b/data_structures/stack/test/linked_list_stack.test.ts
@@ -1,7 +1,7 @@
 import { LinkedListStack } from "../linked_list_stack";
 
 describe("Linked List Stack", () => {
-    let stack: LinkedListStack<number> = new LinkedListStack<number>(4);
+    const stack: LinkedListStack<number> = new LinkedListStack<number>(4);
 
     stack.push(1);
     stack.push(2);

--- a/dynamic_programming/knapsack.ts
+++ b/dynamic_programming/knapsack.ts
@@ -23,7 +23,7 @@ export const knapsack = (
   const numberOfItems = weights.length;
 
   // Declaring a data structure to store calculated states/values
-  let dp: number[][] = new Array(numberOfItems + 1);
+  const dp: number[][] = new Array(numberOfItems + 1);
 
   for (let i = 0; i < dp.length; i++) {
     // Placing an array at each index of dp to make it a 2d matrix

--- a/graph/bellman_ford.ts
+++ b/graph/bellman_ford.ts
@@ -12,7 +12,7 @@
 export const bellmanFord = (graph: [number, number][][], start: number): number[] | undefined => {
   // We save the shortest distance to each node in `distances`. If a node is
   // unreachable from the start node, its distance is Infinity.
-  let distances = Array(graph.length).fill(Infinity);
+  const distances = Array(graph.length).fill(Infinity);
   distances[start] = 0;
 
   // On the i'th iteration, we compute all shortest paths that consists of i+1

--- a/graph/dijkstra.ts
+++ b/graph/dijkstra.ts
@@ -13,17 +13,17 @@ import { MinHeap, PriorityQueue } from '../data_structures/heap/heap';
 export const dijkstra = (graph: [number, number][][], start: number): number[] => {
   // We use a priority queue to make sure we always visit the closest node. The
   // queue makes comparisons based on path weights.
-  let priorityQueue = new PriorityQueue((a: [number, number]) => { return a[0] }, graph.length, (a: [number, number], b: [number, number]) => { return a[1] < b[1] });
+  const priorityQueue = new PriorityQueue((a: [number, number]) => { return a[0] }, graph.length, (a: [number, number], b: [number, number]) => { return a[1] < b[1] });
   priorityQueue.insert([start, 0]);
   // We save the shortest distance to each node in `distances`. If a node is
   // unreachable from the start node, its distance is Infinity.
-  let distances = Array(graph.length).fill(Infinity);
+  const distances = Array(graph.length).fill(Infinity);
   distances[start] = 0;
 
   while (priorityQueue.size() > 0) {
     const [node, _] = priorityQueue.extract();
     graph[node].forEach(([child, weight]) => {
-      let new_distance = distances[node] + weight;
+      const new_distance = distances[node] + weight;
       if (new_distance < distances[child]) {
         // Found a new shortest path to child node. Record its distance and add child to the queue.
         // If the child already exists in the queue, the priority will be updated. This will make sure the queue will be at most size V (number of vertices).

--- a/graph/floyd_warshall.ts
+++ b/graph/floyd_warshall.ts
@@ -10,12 +10,12 @@
  */
 export const floydWarshall = (graph: number[][]): number[][] => {
   let distances = structuredClone(graph);
-  let N = graph.length;
+  const N = graph.length;
 
   // We begin by setting the weighted adjacency matrix as the shortest paths.
   // For the k'th iteration, we try to relax the shortest paths by including node k in the path.
   for (let k = 0; k < N; ++k) {
-    let newDistances = [];
+    const newDistances = [];
     for (let i = 0; i < N; ++i) {
       newDistances.push(Array(N).fill(Infinity));
     }

--- a/graph/johnson.ts
+++ b/graph/johnson.ts
@@ -12,25 +12,25 @@ import { dijkstra } from './dijkstra'
  * @see https://en.wikipedia.org/wiki/Johnson%27s_algorithm
  */
 export const johnson = (graph: [number, number][][]): number[][] | undefined => {
-  let N = graph.length;
+  const N = graph.length;
 
   // Add a new node and 0 weighted edges from the new node to all existing nodes.
-  let newNodeGraph = structuredClone(graph);
-  let newNode: [number, number][] = [];
+  const newNodeGraph = structuredClone(graph);
+  const newNode: [number, number][] = [];
   for (let i = 0; i < N; ++i) {
     newNode.push([i, 0]);
   }
   newNodeGraph.push(newNode);
 
   // Compute distances from the new node to existing nodes using the Bellman-Ford algorithm.
-  let adjustedGraph = bellmanFord(newNodeGraph, N);
+  const adjustedGraph = bellmanFord(newNodeGraph, N);
   if (adjustedGraph === undefined) {
     // Found a negative weight cycle.
     return undefined;
   }
 
   for (let i = 0; i < N; ++i) {
-    for (let edge of graph[i]) {
+    for (const edge of graph[i]) {
       // Adjust edge weights using the Bellman Ford output weights. This ensure that:
       // 1. Each weight is non-negative. This is required for the Dijkstra algorithm.
       // 2. The shortest path from node i to node j consists of the same nodes with or without adjustment.
@@ -38,10 +38,10 @@ export const johnson = (graph: [number, number][][]): number[][] | undefined => 
     }
   }
 
-  let shortestPaths: number[][] = [];
+  const shortestPaths: number[][] = [];
   for (let i = 0; i < N; ++i) {
     // Compute Dijkstra weights for each node and re-adjust weights to their original values.
-    let dijkstraShorestPaths = dijkstra(graph, i);
+    const dijkstraShorestPaths = dijkstra(graph, i);
     for (let j = 0; j < N; ++j) {
       dijkstraShorestPaths[j] += adjustedGraph[j] - adjustedGraph[i];
     }

--- a/graph/kosajaru.ts
+++ b/graph/kosajaru.ts
@@ -14,7 +14,7 @@ const getNodePriorities = (graph: number[][], visited: boolean[], stack: number[
 
 // Return the transpose of graph. The tranpose of a directed graph is a graph where each of the edges are flipped.
 const transpose = (graph: number[][]): number[][] => {
-  let transposedGraph = Array(graph.length);
+  const transposedGraph = Array(graph.length);
   for (let i = 0; i < graph.length; ++i) {
     transposedGraph[i] = [];
   }
@@ -52,20 +52,20 @@ const gatherScc = (graph: number[][], visited: boolean[], node: number, scc: num
  * @see https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
  */
 export const kosajaru = (graph: number[][]): number[][] => {
-  let visited = Array(graph.length).fill(false);
+  const visited = Array(graph.length).fill(false);
 
-  let stack: number[] = [];
+  const stack: number[] = [];
   for (let i = 0; i < graph.length; ++i) {
     getNodePriorities(graph, visited, stack, i);
   }
 
   const transposedGraph = transpose(graph);
 
-  let sccs = [];
+  const sccs = [];
   visited.fill(false);
   for (let i = stack.length - 1; i >= 0; --i) {
     if (!visited[stack[i]]) {
-      let scc: number[] = [];
+      const scc: number[] = [];
       gatherScc(transposedGraph, visited, stack[i], scc);
       sccs.push(scc);
     }

--- a/graph/kruskal.ts
+++ b/graph/kruskal.ts
@@ -13,15 +13,15 @@ import { DisjointSet } from '../data_structures/disjoint_set/disjoint_set';
  */
 export const kruskal = (edges: Edge[], num_vertices: number): [Edge[], number] => {
   let cost = 0;
-  let minimum_spanning_tree = [];
+  const minimum_spanning_tree = [];
 
   // Use a disjoint set to quickly join sets and find if vertices live in different sets
-  let sets = new DisjointSet(num_vertices);
+  const sets = new DisjointSet(num_vertices);
 
   // Sort the edges in ascending order by weight so that we can greedily add cheaper edges to the tree
   edges.sort((a, b) => a.weight - b.weight);
 
-  for (let edge of edges) {
+  for (const edge of edges) {
     if (sets.find(edge.a) !== sets.find(edge.b)) {
       // Node A and B live in different sets. Add edge(a, b) to the tree and join the nodes' sets together.
       minimum_spanning_tree.push(edge);

--- a/graph/prim.ts
+++ b/graph/prim.ts
@@ -13,11 +13,11 @@ export const prim = (graph: [number, number][][]): [Edge[], number] => {
   if (graph.length == 0) {
     return [[], 0];
   }
-  let minimum_spanning_tree: Edge[] = [];
+  const minimum_spanning_tree: Edge[] = [];
   let total_weight = 0;
 
-  let priorityQueue = new PriorityQueue((e: Edge) => { return e.b }, graph.length, (a: Edge, b: Edge) => { return a.weight < b.weight });
-  let visited = new Set<number>();
+  const priorityQueue = new PriorityQueue((e: Edge) => { return e.b }, graph.length, (a: Edge, b: Edge) => { return a.weight < b.weight });
+  const visited = new Set<number>();
 
   // Start from the 0'th node. For fully connected graphs, we can start from any node and still produce the MST.
   visited.add(0);
@@ -25,7 +25,7 @@ export const prim = (graph: [number, number][][]): [Edge[], number] => {
 
   while (!priorityQueue.isEmpty()) {
     // We have already visited vertex `edge.a`. If we have not visited `edge.b` yet, we add its outgoing edges to the PriorityQueue.
-    let edge = priorityQueue.extract();
+    const edge = priorityQueue.extract();
     if (visited.has(edge.b)) {
       continue;
     }
@@ -40,7 +40,7 @@ export const prim = (graph: [number, number][][]): [Edge[], number] => {
 
 const add_children = (graph: [number, number][][], priorityQueue: PriorityQueue<Edge>, node: number) => {
   for (let i = 0; i < graph[node].length; ++i) {
-    let out_edge = graph[node][i];
+    const out_edge = graph[node][i];
     // By increasing the priority, we ensure we only add each vertex to the queue one time, and the queue will be at most size V.
     priorityQueue.increasePriority(out_edge[0], new Edge(node, out_edge[0], out_edge[1]));
   }

--- a/graph/tarjan.ts
+++ b/graph/tarjan.ts
@@ -15,14 +15,14 @@ export const tarjan = (graph: number[][]): number[][] => {
 
   let index = 0;
   // The order in which we discover nodes
-  let discovery: number[] = Array(graph.length);
+  const discovery: number[] = Array(graph.length);
   // For each node, holds the furthest ancestor it can reach
-  let low: number[] = Array(graph.length).fill(undefined);
+  const low: number[] = Array(graph.length).fill(undefined);
   // Holds the nodes we have visited in a DFS traversal and are considering to group into a SCC
-  let stack: number[] = [];
+  const stack: number[] = [];
   // Holds the elements in the stack.
-  let stackContains = Array(graph.length).fill(false);
-  let sccs: number[][] = [];
+  const stackContains = Array(graph.length).fill(false);
+  const sccs: number[][] = [];
 
   const dfs = (node: number) => {
     discovery[node] = index;
@@ -46,7 +46,7 @@ export const tarjan = (graph: number[][]): number[][] => {
 
     if (discovery[node] == low[node]) {
       // node is the root of a SCC. Gather the SCC's nodes from the stack.
-      let scc: number[] = [];
+      const scc: number[] = [];
       let i;
       for (i = stack.length - 1; stack[i] != node; --i) {
         scc.push(stack[i]);

--- a/graph/test/bellman_ford.test.ts
+++ b/graph/test/bellman_ford.test.ts
@@ -1,7 +1,7 @@
 import { bellmanFord } from "../bellman_ford";
 
 const init_graph = (N: number): [number, number][][] => {
-  let graph = Array(N);
+  const graph = Array(N);
   for (let i = 0; i < N; ++i) {
     graph[i] = [];
   }
@@ -16,7 +16,7 @@ describe("bellmanFord", () => {
   }
 
   it("should return the correct value", () => {
-    let graph = init_graph(9);
+    const graph = init_graph(9);
     add_edge(graph, 0, 1, 4);
     add_edge(graph, 0, 7, 8);
     add_edge(graph, 1, 2, 8);
@@ -38,7 +38,7 @@ describe("bellmanFord", () => {
     expect(bellmanFord([[]], 0)).toStrictEqual([0]);
   });
 
-  let linear_graph = init_graph(4);
+  const linear_graph = init_graph(4);
   add_edge(linear_graph, 0, 1, 1);
   add_edge(linear_graph, 1, 2, 2);
   add_edge(linear_graph, 2, 3, 3);
@@ -49,7 +49,7 @@ describe("bellmanFord", () => {
     }
   );
 
-  let unreachable_graph = init_graph(3);
+  const unreachable_graph = init_graph(3);
   add_edge(unreachable_graph, 0, 1, 1);
   test.each([[0, [0, 1, Infinity]], [1, [1, 0, Infinity]], [2, [Infinity, Infinity, 0]]])(
     "correct result for graph with unreachable nodes with source node %i",
@@ -61,7 +61,7 @@ describe("bellmanFord", () => {
 
 describe("bellmanFord negative cycle graphs", () => {
   it("should returned undefined for 2-node graph with negative cycle", () => {
-    let basic = init_graph(2);
+    const basic = init_graph(2);
     basic[0].push([1, 2]);
     basic[1].push([0, -3]);
     expect(bellmanFord(basic, 0)).toStrictEqual(undefined);
@@ -69,7 +69,7 @@ describe("bellmanFord negative cycle graphs", () => {
   });
 
   it("should returned undefined for graph with negative cycle", () => {
-    let negative = init_graph(5);
+    const negative = init_graph(5);
     negative[0].push([1, 6]);
     negative[0].push([3, 7]);
     negative[1].push([2, 5]);

--- a/graph/test/dijkstra.test.ts
+++ b/graph/test/dijkstra.test.ts
@@ -3,7 +3,7 @@ import { dijkstra } from "../dijkstra";
 describe("dijkstra", () => {
 
   const init_graph = (N: number): [number, number][][] => {
-    let graph = Array(N);
+    const graph = Array(N);
     for (let i = 0; i < N; ++i) {
       graph[i] = [];
     }
@@ -16,7 +16,7 @@ describe("dijkstra", () => {
   }
 
   it("should return the correct value", () => {
-    let graph = init_graph(9);
+    const graph = init_graph(9);
     add_edge(graph, 0, 1, 4);
     add_edge(graph, 0, 7, 8);
     add_edge(graph, 1, 2, 8);
@@ -38,7 +38,7 @@ describe("dijkstra", () => {
     expect(dijkstra([[]], 0)).toStrictEqual([0]);
   });
 
-  let linear_graph = init_graph(4);
+  const linear_graph = init_graph(4);
   add_edge(linear_graph, 0, 1, 1);
   add_edge(linear_graph, 1, 2, 2);
   add_edge(linear_graph, 2, 3, 3);
@@ -49,7 +49,7 @@ describe("dijkstra", () => {
     }
   );
 
-  let unreachable_graph = init_graph(3);
+  const unreachable_graph = init_graph(3);
   add_edge(unreachable_graph, 0, 1, 1);
   test.each([[0, [0, 1, Infinity]], [1, [1, 0, Infinity]], [2, [Infinity, Infinity, 0]]])(
     "correct result for graph with unreachable nodes with source node %i",

--- a/graph/test/floyd_warshall.test.ts
+++ b/graph/test/floyd_warshall.test.ts
@@ -14,16 +14,16 @@ describe("floydWarshall", () => {
   });
 
   it("should return the correct value", () => {
-    let graph = [];
+    const graph = [];
     for (let i = 1; i <= 5; ++i) {
-      let arr = [];
+      const arr = [];
       for (let j = 1; j <= 5; ++j) {
         arr.push(i * j);
       }
       graph.push(arr);
     }
 
-    let expected = [
+    const expected = [
       [ 1, 2, 3, 4, 5 ],
       [ 2, 4, 5, 6, 7 ],
       [ 3, 5, 6, 7, 8 ],
@@ -34,7 +34,7 @@ describe("floydWarshall", () => {
   });
 
   it("should return the correct value", () => {
-    let graph = [
+    const graph = [
       [0, 4, Infinity, Infinity, Infinity, Infinity, Infinity, 8, Infinity],
       [4, 0, 8, Infinity, Infinity, Infinity, Infinity, 11, Infinity],
       [Infinity, 8, 0, 7, Infinity, 4, Infinity, Infinity, 2],
@@ -46,7 +46,7 @@ describe("floydWarshall", () => {
       [Infinity, Infinity, 2, Infinity, Infinity, Infinity, 6, 7, 0]
     ];
 
-    let expected = [
+    const expected = [
       [0, 4, 12, 19, 21, 11, 9, 8, 14],
       [4, 0, 8, 15, 22, 12, 12, 11, 10],
       [12, 8, 0, 7, 14, 4, 6, 7, 2],

--- a/graph/test/johnson.test.ts
+++ b/graph/test/johnson.test.ts
@@ -3,7 +3,7 @@ import { johnson } from "../johnson";
 describe("johnson", () => {
 
   const init_graph = (N: number): [number, number][][] => {
-    let graph = Array(N);
+    const graph = Array(N);
     for (let i = 0; i < N; ++i) {
       graph[i] = [];
     }
@@ -16,7 +16,7 @@ describe("johnson", () => {
   }
 
   it("should return the correct value", () => {
-    let graph = init_graph(9);
+    const graph = init_graph(9);
     add_edge(graph, 0, 1, 4);
     add_edge(graph, 0, 7, 8);
     add_edge(graph, 1, 2, 8);
@@ -32,7 +32,7 @@ describe("johnson", () => {
     add_edge(graph, 6, 8, 6);
     add_edge(graph, 7, 8, 7);
 
-    let expected = [
+    const expected = [
       [0, 4, 12, 19, 21, 11, 9, 8, 14],
       [4, 0, 8, 15, 22, 12, 12, 11, 10],
       [12, 8, 0, 7, 14, 4, 6, 7, 2],
@@ -47,14 +47,14 @@ describe("johnson", () => {
   });
 
   it("should return the correct value for graph with negative weights", () => {
-    let graph = init_graph(4);
+    const graph = init_graph(4);
     graph[0].push([1, -5]);
     graph[0].push([2, 2]);
     graph[0].push([3, 3]);
     graph[1].push([2, 4]);
     graph[2].push([3, 1]);
 
-    let expected = [
+    const expected = [
       [ 0, -5, -1, 0 ],
       [ Infinity, 0, 4, 5 ],
       [ Infinity, Infinity, 0, 1 ],
@@ -64,13 +64,13 @@ describe("johnson", () => {
   });
 
   it("should return the undefined for two node graph with negative-weight cycle", () => {
-    let graph = init_graph(2);
+    const graph = init_graph(2);
     add_edge(graph, 0, 1, -1);
     expect(johnson(graph)).toStrictEqual(undefined);
   });
 
   it("should return the undefined for three node graph with negative-weight cycle", () => {
-    let graph = init_graph(3);
+    const graph = init_graph(3);
     graph[0].push([1, -1]);
     graph[0].push([2, 7]);
     graph[1].push([2, -5]);
@@ -87,20 +87,20 @@ describe("johnson", () => {
   });
 
   it("should return the correct value for a linear graph", () => {
-    let linear_graph = init_graph(4);
+    const linear_graph = init_graph(4);
     add_edge(linear_graph, 0, 1, 1);
     add_edge(linear_graph, 1, 2, 2);
     add_edge(linear_graph, 2, 3, 3);
 
-    let expected = [[0, 1, 3, 6 ], [1, 0, 2, 5], [3, 2, 0, 3], [6, 5, 3, 0]];
+    const expected = [[0, 1, 3, 6 ], [1, 0, 2, 5], [3, 2, 0, 3], [6, 5, 3, 0]];
     expect(johnson(linear_graph)).toStrictEqual(expected);
   });
 
   it("should return the correct value for a linear graph with unreachable node", () => {
-    let linear_graph = init_graph(3);
+    const linear_graph = init_graph(3);
     add_edge(linear_graph, 0, 1, 1);
 
-    let expected = [[0, 1, Infinity], [1, 0, Infinity], [Infinity, Infinity, 0]];
+    const expected = [[0, 1, Infinity], [1, 0, Infinity], [Infinity, Infinity, 0]];
     expect(johnson(linear_graph)).toStrictEqual(expected);
   });
 })

--- a/graph/test/kruskal.test.ts
+++ b/graph/test/kruskal.test.ts
@@ -1,12 +1,12 @@
 import { Edge, kruskal } from "../kruskal";
 
-let test_graph = (expected_tree_edges: Edge[], other_edges: Edge[], num_vertices: number, expected_cost: number) => {
-  let [tree_edges, cost] = kruskal(expected_tree_edges.concat(other_edges), num_vertices);
+const test_graph = (expected_tree_edges: Edge[], other_edges: Edge[], num_vertices: number, expected_cost: number) => {
+  const [tree_edges, cost] = kruskal(expected_tree_edges.concat(other_edges), num_vertices);
   expect(cost).toStrictEqual(expected_cost);
-  for (let expected_edge of expected_tree_edges) {
+  for (const expected_edge of expected_tree_edges) {
     expect(tree_edges.includes(expected_edge)).toBeTruthy();
   }
-  for (let unexpected_edge of other_edges) {
+  for (const unexpected_edge of other_edges) {
     expect(tree_edges.includes(unexpected_edge)).toBeFalsy();
   }
 };
@@ -28,13 +28,13 @@ describe("kruskal", () => {
   });
 
   it("should return the correct value", () => {
-    let expected_tree_edges = [
+    const expected_tree_edges = [
       new Edge(0, 1, 1),
       new Edge(1, 3, 2),
       new Edge(2, 3, 3),
     ];
 
-    let other_edges = [
+    const other_edges = [
       new Edge(0, 2, 4),
       new Edge(0, 3, 5),
       new Edge(1, 2, 6),
@@ -44,7 +44,7 @@ describe("kruskal", () => {
   });
 
   it("should return the correct value", () => {
-    let expected_tree_edges = [
+    const expected_tree_edges = [
       new Edge(0, 2, 2),
       new Edge(1, 3, 9),
       new Edge(2, 6, 74),
@@ -56,7 +56,7 @@ describe("kruskal", () => {
       new Edge(8, 9, 2),
     ]
 
-    let other_edges = [
+    const other_edges = [
       new Edge(0, 1, 10),
       new Edge(2, 4, 47),
       new Edge(4, 5, 42),
@@ -69,12 +69,12 @@ describe("kruskal", () => {
 
 describe("kruskal forest", () => {
   it("should return empty tree for forest of 2 node trees", () => {
-    let edges = [new Edge(0, 1, 10), new Edge(2, 3, 15)];
+    const edges = [new Edge(0, 1, 10), new Edge(2, 3, 15)];
     test_graph(edges, [], 4, 25);
   });
 
   it("should return the correct value", () => {
-    let expected_tree_edges = [
+    const expected_tree_edges = [
       // Tree 1
       new Edge(0, 2, 2),
       new Edge(1, 3, 9),
@@ -92,7 +92,7 @@ describe("kruskal forest", () => {
       new Edge(12, 13, 3),
     ]
 
-    let other_edges = [
+    const other_edges = [
       // Tree 1
       new Edge(0, 1, 10),
       new Edge(2, 4, 47),

--- a/graph/test/prim.test.ts
+++ b/graph/test/prim.test.ts
@@ -1,30 +1,30 @@
 import { Edge, prim } from "../prim";
 
-let edge_equal = (x: Edge, y: Edge): boolean => {
+const edge_equal = (x: Edge, y: Edge): boolean => {
   return (x.a == y.a && x.b == y.b) || (x.a == y.b && x.b == y.a) && x.weight == y.weight;
 }
 
-let test_graph = (expected_tree_edges: Edge[], other_edges: Edge[], num_vertices: number, expected_cost: number) => {
+const test_graph = (expected_tree_edges: Edge[], other_edges: Edge[], num_vertices: number, expected_cost: number) => {
   // First make sure the graph is undirected
-  let graph: [number, number][][] = [];
+  const graph: [number, number][][] = [];
   for (let _ = 0; _ < num_vertices; ++_) {
     graph.push([]);
   }
-  for (let edge of expected_tree_edges) {
+  for (const edge of expected_tree_edges) {
     graph[edge.a].push([edge.b, edge.weight]);
     graph[edge.b].push([edge.a, edge.weight]);
   }
-  for (let edge of other_edges) {
+  for (const edge of other_edges) {
     graph[edge.a].push([edge.b, edge.weight]);
     graph[edge.b].push([edge.a, edge.weight]);
   }
 
-  let [tree_edges, cost] = prim(graph);
+  const [tree_edges, cost] = prim(graph);
   expect(cost).toStrictEqual(expected_cost);
-  for (let expected_edge of expected_tree_edges) {
+  for (const expected_edge of expected_tree_edges) {
     expect(tree_edges.find(edge => edge_equal(edge, expected_edge))).toBeTruthy();
   }
-  for (let unexpected_edge of other_edges) {
+  for (const unexpected_edge of other_edges) {
     expect(tree_edges.find(edge => edge_equal(edge, unexpected_edge))).toBeFalsy();
   }
 };
@@ -45,13 +45,13 @@ describe("prim", () => {
   });
 
   it("should return the correct value", () => {
-    let expected_tree_edges = [
+    const expected_tree_edges = [
       new Edge(0, 1, 1),
       new Edge(1, 3, 2),
       new Edge(3, 2, 3),
     ];
 
-    let other_edges = [
+    const other_edges = [
       new Edge(0, 2, 4),
       new Edge(0, 3, 5),
       new Edge(1, 2, 6),
@@ -61,7 +61,7 @@ describe("prim", () => {
   });
 
   it("should return the correct value", () => {
-    let expected_tree_edges = [
+    const expected_tree_edges = [
       new Edge(0, 2, 2),
       new Edge(1, 3, 9),
       new Edge(2, 6, 74),
@@ -73,7 +73,7 @@ describe("prim", () => {
       new Edge(8, 9, 2),
     ]
 
-    let other_edges = [
+    const other_edges = [
       new Edge(0, 1, 10),
       new Edge(2, 4, 47),
       new Edge(4, 5, 42),

--- a/maths/calculate_median.ts
+++ b/maths/calculate_median.ts
@@ -16,10 +16,10 @@ export const calculateMedian = (numbers: number[]): number => {
     const totalNumbers = numbers.length;
 
     if (totalNumbers % 2 === 0) {
-        let index = totalNumbers / 2;
+        const index = totalNumbers / 2;
         return (numbers[index - 1] + numbers[index]) / 2;
     } else {
-        let index = (totalNumbers + 1) / 2;
+        const index = (totalNumbers + 1) / 2;
         return numbers[index - 1];
     }
 };

--- a/maths/matrix_multiplication.ts
+++ b/maths/matrix_multiplication.ts
@@ -13,7 +13,7 @@ function matrixMultiplication(matA: number[][], b: number[][]): number[][];
 function matrixMultiplication(matA: number[][], b: number): number[][];
 function matrixMultiplication(matA: number[][], b: number[]): number[];
 
-function matrixMultiplication(matA: number[][], b: any): Number[][] | Number[] | null {
+function matrixMultiplication(matA: number[][], b: any): number[][] | number[] | null {
   let matC: any = null;
 
   if (typeof b === 'number') {

--- a/maths/pascals_triangle.ts
+++ b/maths/pascals_triangle.ts
@@ -15,15 +15,15 @@
  * @see https://en.wikipedia.org/wiki/Pascal's_triangle
  */
 export const pascalsTriangle = (n: number): number[] => {
-  let arr: number[][] = [];
+  const arr: number[][] = [];
   for (let i: number = 0; i < n; i++) {
     if (i === 0) {
       arr.push([1]);
       continue;
     }
 
-    let lastRow: number[] = arr[i - 1];
-    let temp: number[] = [];
+    const lastRow: number[] = arr[i - 1];
+    const temp: number[] = [];
     for (let j: number = 0; j < lastRow.length + 1; j++) {
       if (j === 0 || j === lastRow.length) {
         temp.push(1);

--- a/maths/perfect_number.ts
+++ b/maths/perfect_number.ts
@@ -13,7 +13,7 @@ export const isPerfectNumber = (n: number): boolean => {
         return false;
     }
     let sum = 1;
-    let sqrt = Math.sqrt(n);
+    const sqrt = Math.sqrt(n);
     for (let i = 2; i < sqrt; i++) {
         if (n % i === 0) {
             sum += i + n / i;

--- a/maths/prime_factorization.ts
+++ b/maths/prime_factorization.ts
@@ -7,7 +7,7 @@
  * @example factorize(5) = Map {5 => 1}
  */
 export const factorize = (n: number): Map<number, number> => {
-    let result: Map<number, number> = new Map();
+    const result: Map<number, number> = new Map();
 
     for (let i = 2; i * i <= n; i++) {
         while (n % i == 0) {

--- a/sorts/bubble_sort.ts
+++ b/sorts/bubble_sort.ts
@@ -22,7 +22,7 @@ export const bubbleSort = (arr: number[]): number[] => {
   for (let i = 0; i < arr.length; i++) { 
     for (let j = 0; j < arr.length-1; j++) { //iterating till the 2nd last element of array
       if (arr[j] > arr[j+1]) {         //current indexed number > next indexed number
-        let temp: number = arr[j];   //swapping two numbers
+        const temp: number = arr[j];   //swapping two numbers
         arr[j] = arr[j+1];
         arr[j+1] = temp;
       }

--- a/sorts/quick_select.ts
+++ b/sorts/quick_select.ts
@@ -25,7 +25,7 @@ export const QuickSelect = (
     }
 
     // Partition the array
-    let pivotIndex = partition(array, left, right);
+    const pivotIndex = partition(array, left, right);
 
     // The pivot is in its final sorted position
     if (k === pivotIndex) {

--- a/sorts/swap_sort.ts
+++ b/sorts/swap_sort.ts
@@ -12,7 +12,7 @@ export const minSwapsToSort =  (inputArr: number[]): number => {
     
     sortedArray.sort()
 
-    let indexMap = new Map();
+    const indexMap = new Map();
 
     for (let i = 0; i < inputArr.length; i++)
       indexMap.set(inputArr[i],i);

--- a/sorts/test/merge_sort.test.ts
+++ b/sorts/test/merge_sort.test.ts
@@ -2,14 +2,14 @@ import { mergeSort } from "../merge_sort"
 
 describe("Merge Sort", () => {
   it("generating array with variable length and comparing with sorted array", () => {
-    let arrLenArr = [10, 200, 40000]
+    const arrLenArr = [10, 200, 40000]
 
     arrLenArr.forEach((arrLen: number) => {
-      let inBuiltSortArr = Array<number>(arrLen)
+      const inBuiltSortArr = Array<number>(arrLen)
       for (let i = 0; i < arrLen; i++) {
         inBuiltSortArr[i] = Math.random() * 10000
       }
-      let mergeSortArray = inBuiltSortArr.slice()
+      const mergeSortArray = inBuiltSortArr.slice()
 
       inBuiltSortArr.sort((a, b) => a - b)
       expect(mergeSort(mergeSortArray)).toStrictEqual(inBuiltSortArr)


### PR DESCRIPTION
As suggested [here](https://github.com/TheAlgorithms/TypeScript/pull/229#pullrequestreview-1874379167), I stared exploring _linting_/static analysis tools available for TypeScript. The [TypeScipt eslint](https://typescript-eslint.io) seems to be reasonable. These changes are the result of running `npx eslint . --fix`, and from what I see it has changed `let` to `const`, which is a tiny step in a good direction.