### PR TITLE
style: simplify `binaryLCM`

### DIFF
--- a/maths/lowest_common_multiple.ts
+++ b/maths/lowest_common_multiple.ts
@@ -38,14 +38,6 @@ export const naiveLCM = (nums: number[]): number => {
 //Note that due to utilizing GCF, which requires natural numbers, this method only accepts natural numbers.
 
 export const binaryLCM = (a: number, b: number): number => {
-  if (a < 0 || b < 0) {
-    throw new Error("numbers must be positive to determine lowest common multiple");
-  }
-
-  if (!Number.isInteger(a) || !Number.isInteger(b)) {
-    throw new Error("this method, which utilizes GCF, requires natural numbers.");
-  }
-
   return a * b / greatestCommonFactor([a, b]);
 }
 

--- a/maths/test/lowest_common_multiple.test.ts
+++ b/maths/test/lowest_common_multiple.test.ts
@@ -29,10 +29,15 @@ describe("binaryLCM", () => {
     },
   );
 
-  test("only whole numbers should be accepted", () => {
-    expect(() => binaryLCM(-2, -3)).toThrowError(
-      "numbers must be positive to determine lowest common multiple",
-    );
+  test("only natural numbers should be accepted", () => {
+    expect(() => binaryLCM(-2, -3)).toThrowError();
+    expect(() => binaryLCM(2, -3)).toThrowError();
+    expect(() => binaryLCM(-2, 3)).toThrowError();
+  });
+
+  test("should throw when any of the inputs is not an int", () => {
+    expect(() => binaryLCM(1, 2.5)).toThrowError();
+    expect(() => binaryLCM(1.5, 2)).toThrowError();
   });
 });
 
@@ -45,9 +50,7 @@ describe("lowestCommonMultiple", () => {
   );
 
   test("only positive numbers should be accepted", () => {
-    expect(() => lowestCommonMultiple([-2, -3])).toThrowError(
-      "numbers must be positive to determine lowest common multiple",
-    );
+    expect(() => lowestCommonMultiple([-2, -3])).toThrowError();
   });
 
   test("at least one number must be passed in", () => {


### PR DESCRIPTION
This PR simplifies `binaryLCM` by removing redundant branches (they are present in `binaryGCF`).