### PR TITLE
style: fix some eslint warnings

### DIFF
--- a/graph/dijkstra.ts
+++ b/graph/dijkstra.ts
@@ -1,4 +1,4 @@
-import { MinHeap, PriorityQueue } from '../data_structures/heap/heap'
+import { PriorityQueue } from '../data_structures/heap/heap'
 /**
  * @function dijkstra
  * @description Compute the shortest path from a source node to all other nodes. The input graph is in adjacency list form. It is a multidimensional array of edges. graph[i] holds the edges for the i'th node. Each edge is a 2-tuple where the 0'th item is the destination node, and the 1'th item is the edge weight.
@@ -32,7 +32,7 @@ export const dijkstra = (
   distances[start] = 0
 
   while (priorityQueue.size() > 0) {
-    const [node, _] = priorityQueue.extract()
+    const node = priorityQueue.extract()[0]
     graph[node].forEach(([child, weight]) => {
       const new_distance = distances[node] + weight
       if (new_distance < distances[child]) {

--- a/search/jump_search.ts
+++ b/search/jump_search.ts
@@ -22,8 +22,8 @@ export const jumpSearch = (array: number[], target: number): number => {
   if (array.length === 0) return -1
 
   // declare pointers for the current and next indexes and step size
+  const stepSize: number = Math.floor(Math.sqrt(array.length))
   let currentIdx: number = 0,
-    stepSize: number = Math.floor(Math.sqrt(array.length)),
     nextIdx: number = stepSize
 
   while (array[nextIdx - 1] < target) {


### PR DESCRIPTION
This PR fixes some eslint warnings, namely:
```
/workspace/TypeScript/graph/dijkstra.ts
   1:10  error  'MinHeap' is defined but never used     @typescript-eslint/no-unused-vars
  35:18  error  '_' is assigned a value but never used  @typescript-eslint/no-unused-vars
```
and
```
/workspace/TypeScript/search/jump_search.ts
  26:5  error  'stepSize' is never reassigned. Use 'const' instead  prefer-const
```

Continuation of #230.