### PR TITLE
style: use `T[]` instead of `Array<T>`

### DIFF
--- a/sorts/shell_sort.ts
+++ b/sorts/shell_sort.ts
@@ -9,11 +9,11 @@
  *      Average case -  O(n log(n)^2)
  *
  * @param {T[]} arr - The input array
- * @return {Array<T>} - The sorted array.
+ * @return {T[]} - The sorted array.
  * @see [Shell Sort] (https://www.geeksforgeeks.org/shellsort/)
  * @example shellSort([4, 1, 8, 10, 3, 2, 5, 0, 7, 6, 9]) = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
  */
-export function shellSort<T>(arr: T[]): Array<T> {
+export function shellSort<T>(arr: T[]): T[] {
   // start with the biggest gap, reduce gap twice on each step
   for (let gap = arr.length >> 1; gap > 0; gap >>= 1) {
     for (let i = gap; i < arr.length; i++) {


### PR DESCRIPTION
Fixes the [array-type](https://typescript-eslint.io/rules/array-type/) warning.

Similar to:
- #230,
- #240,
- #241,
- #242.