### PR TITLE
feat(maths): add bisection method

### DIFF
--- a/maths/bisection.ts
+++ b/maths/bisection.ts
@@ -1,0 +1,61 @@
+/**
+ * 
+ * @description Find the root of a function within a given interval using the bisection method.
+ * @param f The function for which the root is being sought
+ * @param a The start of the interval
+ * @param b The end of the interval
+ * @param tol The tolerance value, determining the precision of the root
+ * @param maxIter The maximum number of iterations
+ * @returns The approximate root of the function, or null if no root is found
+ * @throws Error if f(a) and f(b) do not have opposite signs
+ * @throws Error if f is not a function
+ * @see https://en.wikipedia.org/wiki/Bisection_method
+ * @example bisection(x => x * x - 2, 1, 2) returns Math.sqrt(2)
+ * @example bisection(x => x * x * x - 4, 1, 2) returns Math.cbrt(4)
+ */
+export function bisection(
+  f: (x: number) => number,
+  a: number,
+  b: number,
+  tol = 1e-7,
+  maxIter = 100
+): number | null {
+  
+  if (typeof f !== 'function') {
+    throw new Error("The first argument must be a function.")
+  }
+
+  const fa = f(a)
+  const fb = f(b)
+  
+  if (fa * fb >= 0) {
+    throw new Error("The function must have opposite signs at the endpoints a and b.")
+  }
+
+  let iter = 0
+  let left = a
+  let right = b
+  
+  while (iter < maxIter) {
+    const mid = (left + right) / 2
+    const fMid = f(mid)
+    
+    if (Math.abs(fMid) < tol) {
+      return mid
+    }
+    
+    if (Math.abs(right - left) < tol) {
+      return mid
+    }
+    
+    if (fa * fMid < 0) {
+      right = mid
+    } else {
+      left = mid
+    }
+    
+    iter++
+  }
+  
+  return null
+}

--- a/maths/test/bisection.test.ts
+++ b/maths/test/bisection.test.ts
@@ -1,0 +1,32 @@
+import { bisection } from '../bisection';
+
+const f = (x: number): number => x * x - 2;
+const g = (x: number): number => x * x * x - 4;
+
+describe('Bisection Method with multiple functions', () => {
+    
+    test.each([
+        [1, 2, Math.sqrt(2)],     
+        [0, 2, Math.sqrt(2)],
+    ])('should find the root of f(x) = x^2 - 2 in range (%i, %i)', (a, b, expected) => {
+        const root = bisection(f, a, b, 1e-7, 100);
+        expect(root).toBeCloseTo(expected, 6);
+    });
+
+    
+    test.each([
+        [1, 2, Math.cbrt(4)],     
+        [1, 3, Math.cbrt(4)],     
+    ])('should find the root of g(x) = x^3 - 4 in range (%i, %i)', (a, b, expected) => {
+        const root = bisection(g, a, b, 1e-7, 100);
+        expect(root).toBeCloseTo(expected, 6);
+    });
+
+
+    test('should throw error for invalid range', () => {
+        expect(() => bisection(f, -1, 1, 1e-7, 100)).toThrow(
+            'The function must have opposite signs at the endpoints a and b.'
+        );
+    });
+
+});


### PR DESCRIPTION

This PR adds the **Bisection Method** to the `maths` module.

### Changes:
- Added `bisection` function to solve equations of the form `f(x) = 0`.
- Created tests for the new function.

### Issue Reference:
Closes #10

### Notes:
- The bisection method finds roots by repeatedly halving the interval.
