### PR TITLE
feat: add Comb Sort algorithm

### DIFF
--- a/sorts/comb_sort.ts
+++ b/sorts/comb_sort.ts
@@ -1,0 +1,32 @@
+/**
+ * @function combSort
+ * @description Comb sort improves on bubble sort by comparing elements separated by a gap that shrinks each pass (by a factor of ~1.3), removing small values stuck near the end ("turtles") much faster than bubble sort.
+ * @param {number[]} arr - The input array
+ * @return {number[]} - The sorted array.
+ * @see [CombSort] https://en.wikipedia.org/wiki/Comb_sort
+ * @example combSort([8, 3, 5, 1, 4, 2]) = [1, 2, 3, 4, 5, 8]
+ */
+
+export const combSort = (arr: number[]): number[] => {
+  const shrinkFactor = 1.3
+  let gap = arr.length
+  let isSorted = false
+
+  while (!isSorted) {
+    gap = Math.floor(gap / shrinkFactor)
+
+    if (gap <= 1) {
+      gap = 1
+      isSorted = true
+    }
+
+    for (let i = 0; i + gap < arr.length; i++) {
+      if (arr[i] > arr[i + gap]) {
+        ;[arr[i], arr[i + gap]] = [arr[i + gap], arr[i]]
+        isSorted = false
+      }
+    }
+  }
+
+  return arr
+}

--- a/sorts/test/comb_sort.test.ts
+++ b/sorts/test/comb_sort.test.ts
@@ -1,0 +1,21 @@
+import { combSort } from '../comb_sort'
+
+describe('Testing Comb sort', () => {
+  const testCases: number[][] = [
+    [],
+    [2, 1],
+    [8, 3, 5, 9, 1, 7, 4, 2, 6],
+    [9, 8, 7, 6, 5, 4, 3, 2, 1],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    [1, 1, 1, 1, 1, 1, 1, 1, 1]
+  ]
+
+  test.each(testCases)(
+    'should return the correct value for test case: %#',
+    (...arr: number[]) => {
+      expect(combSort([...arr])).toStrictEqual(
+        [...arr].sort((a: number, b: number) => a - b)
+      )
+    }
+  )
+})


### PR DESCRIPTION
### Description

Adds the **Comb Sort** algorithm to `sorts/`.

Comb sort is an improvement over bubble sort: instead of always comparing adjacent elements, it compares elements separated by a `gap` that starts large and shrinks each pass by a factor of ~1.3. This quickly moves small values stuck near the end (so-called "turtles") toward the front, giving much better practical performance than bubble sort while staying simple and in-place.

- Average / worst time complexity: `O(n^2 / 2^p)` (where `p` = number of increments) → close to `O(n log n)` in practice, `O(n^2)` worst case
- Space complexity: `O(1)` (in-place)

### Checklist

- [x] New algorithm implementation under `sorts/comb_sort.ts`
- [x] Tests added under `sorts/test/comb_sort.test.ts` (empty, sorted, reverse, duplicates, random)
- [x] Follows the repository style (JSDoc header, named export) and passes Prettier
- [x] Self-reviewed the code
